### PR TITLE
Ensure that all docs are migrated

### DIFF
--- a/tools/migrate.py
+++ b/tools/migrate.py
@@ -135,7 +135,7 @@ async def main():
 
         if len(bulk_array) > 100:
             await bulk_push(bulk_array)
-            bulk_array = []
+            bulk_array[:] = []
 
         processed += 1
         if processed % 500 == 0:
@@ -155,6 +155,10 @@ async def main():
             print("Processed %u emails, %u remain. ETA: %s (at %u emails per second)" %
                   (processed, (no_emails - processed), time_left_str, docs_per_second)
                   )
+
+    # There may be some docs left over to push
+    if bulk_array:
+        await bulk_push(bulk_array)
 
     start_time = time.time()
     processed = 0


### PR DESCRIPTION
This PR fixes a bug where `migrate.py` would not migrate all documents. The problem is that in the loop iterating over all documents in the source database, documents are appended gradually into a buffer. When the buffer size exceeds 100, the whole buffer is bulk pushed and then cleared. This leads to a "leftovers" problem if the number of source document is not an exact multiple of 100, meaning that up to 99 documents may be left in the buffer after the final loop and never pushed because the buffer size did not exceed 100.

The fix suggested in this PR is to add an extra check after the loop, bulk pushing the buffer again if the buffer size is greater than 0. The problem only exists for the mbox and source indices; attachments are handled one-by-one, and have no buffer.
