### PR TITLE
Fix static lists JS and comment out

### DIFF
--- a/webui/list.html
+++ b/webui/list.html
@@ -92,7 +92,7 @@ the License. -->
               <li><a href="javascript:void(0)" onclick="set_theme('threaded')">Threaded view</a></li>
               <li><a href="javascript:void(0)" onclick="set_theme('flat')">Flat view</a></li>
               <li><a href="javascript:void(0)" onclick="set_theme('treeview')">Treview</a></li>
-              <li><a href="api/static.lua/" onclick="location.href='/api/static.lua/' + xlist;return false;">Static HTML lists</a></li>
+              <!-- <li><a href="api/static.lua/" onclick="location.href='/api/static.lua/' + current_list + '@' + current_domain;return false;">Static HTML lists</a></li> -->
           </ul>
         </li>
       <li id="threading_mobile" class="navbar-right" style="display: none;">


### PR DESCRIPTION
The "Static HTML lists" link is broken due to `xlist` not being defined. Most likely it should be `current_list + '@' + current_domain`. In any case, the link is broken even with this fix because `/api/static.lua/list@example.org` returns "API Endpoint not found!". This PR therefore fixes the JS but also comments out the link, ready for uncommenting when the static list API is ported.