### PR TITLE
Increase the number of lists returned during term aggregation

### DIFF
--- a/server/plugins/background.py
+++ b/server/plugins/background.py
@@ -40,12 +40,13 @@ async def get_lists(database: plugins.configuration.DBConfig) -> dict:
     """
     lists = {}
     db = plugins.database.Database(database)
+    limit = 8192
 
     # Fetch aggregations of all public emails
-    s = Search(using=db.client, index=database.db_prefix + "-mbox").query(
-        "match", private=False
+    s = Search(using=db.client, index=database.db_prefix + "-mbox").filter(
+        "term", private=False
     )
-    s.aggs.bucket("per_list", "terms", field="list_raw")
+    s.aggs.bucket("per_list", "terms", field="list_raw", size=limit)
 
     res = await db.search(
         index=database.db_prefix + "-mbox", body=s.to_dict(), size=0
@@ -59,10 +60,10 @@ async def get_lists(database: plugins.configuration.DBConfig) -> dict:
         }
 
     # Ditto, for private emails
-    s = Search(using=db.client, index=database.db_prefix + "-mbox").query(
-        "match", private=True
+    s = Search(using=db.client, index=database.db_prefix + "-mbox").filter(
+        "term", private=True
     )
-    s.aggs.bucket("per_list", "terms", field="list_raw")
+    s.aggs.bucket("per_list", "terms", field="list_raw", size=limit)
 
     res = await db.search(
         index=database.db_prefix + "-mbox", body=s.to_dict(), size=0


### PR DESCRIPTION
Foal does not correctly discover all lists available to it from its Elasticsearch database because the underlying aggregation query does not specify a size, and so the default of ten is used. This means that Foal will only ever discover up to ten available mailing lists.

Unfortunately it is not possible to fix this by specifying `size=0` as in other Elasticsearch queries to receive unbounded results. If you try this for a term aggregation you get a error along the lines of:

```
elasticsearch.exceptions.RequestError:
  RequestError(400, 'x_content_parse_exception', '[1:114] [terms] failed to parse field [size]')
```

Therefore this PR raises the limit to `8192` mailing lists, meaning that at most `8192` mailing lists will be correctly discovered. This number was chosen arbitrarily.
