### PR TITLE
Add focus_domain preference to restrict lists to the current domain

### DIFF
--- a/server/endpoints/preferences.py
+++ b/server/endpoints/preferences.py
@@ -32,8 +32,11 @@ async def process(server: plugins.server.BaseServer, session: plugins.session.Se
             can_access = True
             if entry.get("private", False):
                 can_access = plugins.aaa.can_access_list(session, ml)
-            if server.config.ui.focus_domain:
-                if ldomain != session.host:
+            if server.config.ui.focus_domain != "*":
+                if server.config.ui.focus_domain.startswith("*."):
+                    if not ldomain.endswith(server.config.ui.focus_domain[1:]):
+                        continue
+                elif ldomain != (server.config.ui.focus_domain or session.host):
                     continue
             if can_access:
                 if ldomain not in lists:

--- a/server/endpoints/preferences.py
+++ b/server/endpoints/preferences.py
@@ -32,6 +32,9 @@ async def process(server: plugins.server.BaseServer, session: plugins.session.Se
             can_access = True
             if entry.get("private", False):
                 can_access = plugins.aaa.can_access_list(session, ml)
+            if server.config.ui.focus_domain:
+                if ldomain != session.host:
+                    continue
             if can_access:
                 if ldomain not in lists:
                     lists[ldomain] = {}

--- a/server/plugins/configuration.py
+++ b/server/plugins/configuration.py
@@ -20,6 +20,7 @@ class UIConfig:
     sender_domains: str
     traceback: bool
     mgmt_enabled: bool
+    focus_domain: bool
 
     def __init__(self, subyaml: dict):
         self.wordcloud = bool(subyaml.get("wordcloud", False))
@@ -31,6 +32,7 @@ class UIConfig:
         # Set to false in yaml to redirect to stderr instead.
         self.traceback = subyaml.get("traceback", True)
         self.mgmt_enabled = bool(subyaml.get("mgmtconsole", False))  # Whether to enable online mgmt component or not
+        self.focus_domain = bool(subyaml.get("focus_domain", False))
 
 
 class OAuthConfig:

--- a/server/plugins/configuration.py
+++ b/server/plugins/configuration.py
@@ -20,7 +20,7 @@ class UIConfig:
     sender_domains: str
     traceback: bool
     mgmt_enabled: bool
-    focus_domain: bool
+    focus_domain: str
 
     def __init__(self, subyaml: dict):
         self.wordcloud = bool(subyaml.get("wordcloud", False))
@@ -32,7 +32,8 @@ class UIConfig:
         # Set to false in yaml to redirect to stderr instead.
         self.traceback = subyaml.get("traceback", True)
         self.mgmt_enabled = bool(subyaml.get("mgmtconsole", False))  # Whether to enable online mgmt component or not
-        self.focus_domain = bool(subyaml.get("focus_domain", False))
+        # Default to all lists, "*". Use "" for host. Wildcard subdomain globs also supported
+        self.focus_domain = subyaml.get("focus_domain", "*")
 
 
 class OAuthConfig:


### PR DESCRIPTION
When hosting Foal across multiple domains or subdomains it may be desirable to show only the mailing lists for the current domain or subdomain in the user interface. This PR adds a boolean configuration option called `ui.focus_domain`, set to `False` by default, which when set to `True` implements this functionality.
