### PR TITLE
Use dbid instead of mid to get source

### DIFF
--- a/server/endpoints/source.py
+++ b/server/endpoints/source.py
@@ -36,7 +36,7 @@ async def process(
 
     if email and isinstance(email, dict) and not email.get("deleted"):
         if plugins.aaa.can_access_email(session, email):
-            source = await plugins.mbox.get_source(session, permalink=email["mid"])
+            source = await plugins.mbox.get_source(session, permalink=email["dbid"])
             if source and not source["_source"].get("deleted"):
                 return aiohttp.web.Response(
                     headers={"Content-Type": "text/plain"}, status=200, text=source["_source"]["source"],


### PR DESCRIPTION
This PR fixes a small bug in the source endpoint. The `mid` field was being used to retrieve a source document, which was correct for Ponymail but in Foal the `dbid` field is used instead.