### PR TITLE
Add the blakey generator based on BLAKE3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 PyYAML~=5.3.1
+blake3~=0.1.8
 elasticsearch-dsl>=7.0.0,<8.0.0
 elasticsearch[async]>=7.10.1
 certifi~=2020.6.20

--- a/tools/migrate.py
+++ b/tools/migrate.py
@@ -47,11 +47,11 @@ async def main():
     old_dbname = input("What is the database name for the old Pony Mail emails? [ponymail]: ") or "ponymail"
     new_dbprefix = input("What is the database prefix for the new Pony Mail emails? [ponymail]: ") or "ponymail"
 
-    do_dkim = True
-    dkim_txt = input("Do you wish to perform DKIM re-indexing of all emails? This will still preserve old permalinks "
+    do_blakey = True
+    blakey_txt = input("Do you wish to perform blakey re-indexing of all emails? This will still preserve old permalinks "
                      "(y/n) [y]: ") or "y"
-    if dkim_txt.lower() == 'n':
-        do_dkim = False
+    if blakey_txt.lower() == 'n':
+        do_blakey = False
 
     # Define index names for new ES
     dbname_mbox = new_dbprefix + "-mbox"
@@ -92,12 +92,12 @@ async def main():
             source_text = base64.b64decode(source_text)
         else:  # bytify
             source_text = source_text.encode('utf-8', 'ignore')
-        if do_dkim:
-            dkim_id = plugins.generators.dkim(None, None, list_id, None, source_text)
+        if do_blakey:
+            blakey_id = plugins.generators.blakey(None, None, list_id, None, source_text)
             old_id = doc['_id']
-            doc['_source']['mid'] = dkim_id
+            doc['_source']['mid'] = blakey_id
             doc['_source']['permalinks'] = [
-                dkim_id,
+                blakey_id,
                 old_id
             ]
         else:
@@ -116,9 +116,9 @@ async def main():
         notes.append("MIGRATE: Document migrated from Pony Mail to Pony Mail Foal at %u, "
                      "using foal migrator v/%s" % (now, MIGRATION_MAGIC_NUMBER))
         # If we re-indexed the document, make a note of that as well.
-        if do_dkim:
-            notes.append("REINDEX: Document re-indexed with DKIM_ID at %u, "
-                         "from %s to %s" % (now, dkim_id, old_id))
+        if do_blakey:
+            notes.append("REINDEX: Document re-indexed with blakey at %u, "
+                         "from %s to %s" % (now, blakey_id, old_id))
         doc['_source']['_notes'] = notes
 
         # Copy to new DB

--- a/tools/plugins/generators.py
+++ b/tools/plugins/generators.py
@@ -22,112 +22,53 @@ For older ID generators, see generators_old.py
 
 import base64
 import hashlib
-import typing
+import sys
+
 import plugins.generators_old
 
-# For optional nonce
-config: typing.Optional[dict] = None
+try:
+    import blake3
+except ImportError:
+    if sys.version_info >= (3, 10):
+        if "blake3" not in hashlib.algorithms_available:
+            raise RuntimeError("BLAKE3 is not supported")
 
-# Headers from RFC 4871, the precursor to RFC 6376
-rfc4871_subset = {
-    b"from", b"sender", b"reply-to", b"subject", b"date",
-    b"message-id", b"to", b"cc", b"mime-version", b"content-type",
-    b"content-transfer-encoding", b"content-id",
-    b"content-description", b"resent-date", b"resent-from",
-    b"resent-sender", b"resent-to", b"resent-cc",
-    b"resent-message-id", b"in-reply-to", b"references", b"list-id",
-    b"list-help", b"list-unsubscribe", b"list-subscribe",
-    b"list-post", b"list-owner", b"list-archive", b"dkim-signature"
-}
+        def blake3_context_160(lid: str, message: bytes) -> bytes:
+            h = hashlib.blake3(message, derive_key_context=lid)
+            return h.digest(length=160 // 8)
 
-# Authenticity headers from RFC 8617
-rfc4871_and_rfc8617_subset = rfc4871_subset | {
-    b"arc-authentication-results", b"arc-message-signature",
-    b"arc-seal"
-}
+    else:
+        raise RuntimeError("BLAKE3 is not supported")
+else:
 
-
-def rfc822_parse_dkim(suffix,
-                      head_canon=False, body_canon=False,
-                      head_subset=None, archive_list_id=None):
-    headers = []
-    keep = True
-    list_ids = set()
-
-    while suffix:
-        # Edge case: headers don't end LF (add LF)
-        line, suffix = (suffix.split(b"\n", 1) + [b""])[:2]
-        if line in {b"\r", b""}:
-            break
-        end = b"\n" if line.endswith(b"\r") else b"\r\n"
-        if line[0] in {0x09, 0x20}:
-            # Edge case: starts with a continuation (treat like From)
-            if headers and (keep is True):
-                headers[-1][1] += line + end
-        elif not line.startswith(b"From "):
-            # Edge case: header start contains no colon (use whole line)
-            # "A field-name MUST be contained on one line." (RFC 822 B.2)
-            k, v = (line.split(b":", 1) + [b""])[:2]
-            k_lower = k.lower()
-            if k_lower == "list-id":
-                list_ids.add(k_lower)
-            if (head_subset is None) or (k_lower in head_subset):
-                keep = True
-                headers.append([k, v + end])
-            else:
-                keep = False
-    # The remaining suffix is the body
-    body = suffix.replace(b"\r\n", b"\n")
-    body = body.replace(b"\n", b"\r\n")
-
-    # Optional X-Archive-List-ID augmentation
-    if (archive_list_id is not None) and (archive_list_id not in list_ids):
-        xali_value = b" " + bytes(archive_list_id, "ascii")
-        headers.append([b"X-Archive-List-ID", xali_value])
-    # Optional nonce from local config
-    if config is not None:
-        if (config.get("archiver") and
-                config['archiver'].get('nonce')):
-            nonce = config['archiver'].get('nonce')
-            headers.append([b"X-Archive-Nonce", nonce])
-    # Optional head canonicalisation (DKIM relaxed)
-    if head_canon is True:
-        for i in range(len(headers)):
-            k, v = headers[i]
-            crlf = v.endswith(b"\r\n")
-            if crlf is True:
-                v = v[:-2]
-            v = v.replace(b"\r\n", b"")
-            v = v.replace(b"\t", b" ")
-            v = v.strip(b" ")
-            v = b" ".join(vv for vv in v.split(b" ") if vv)
-            if crlf is True:
-                v = v + b"\r\n"
-            headers[i] = [k.lower(), v]
-    # Optional body canonicalisation (DKIM simple)
-    if body_canon is True:
-        while body.endswith(b"\r\n\r\n"):
-            body = body[:-2]
-    return (headers, body)
+    def blake3_context_160(lid: str, message: bytes) -> bytes:
+        if "`context`" in blake3.blake3.__doc__:
+            # NOTE: Can be removed when blake3 0.1.9 or 0.2.0 is published
+            h = blake3.blake3(message, context=lid)
+        else:
+            h = blake3.blake3(message, derive_key_context=lid)
+        return h.digest(length=160 // 8)
 
 
-def pibble(hashable, size=10):
-    table = bytes.maketrans(
+def pibble32(data: bytes) -> str:
+    r"""
+    Base32 encodes bytes with alphabet 0-9 b-d f-h j-t v-z.
+
+    >>> pibble32(b"\xca\xfe\xc0\xff\xee")
+    'sczd1zzg'
+    """
+    table: bytes = bytes.maketrans(
         b"ABCDEFGHIJKLMNOPQRSTUVWXYZ234567",
         b"0123456789bcdfghjklmnopqrstvwxyz",
     )
-    digest = hashlib.sha3_256(hashable).digest()
-    prefix = digest[:size]
-    encoded = base64.b32encode(prefix)
+    encoded: bytes = base64.b32encode(data)
     return str(encoded.translate(table), "ascii")
 
 
-# DKIM generator: uses DKIM canonicalisation
-# Used by default
-def dkim(_msg, _body, lid, _attachments, raw_msg):
-    """
-    DKIM generator: uses DKIM relaxed/simple canonicalisation
-    We use the headers recommended in RFC 4871, plus DKIM-Signature
+def blakey(_msg, _body, lid, _attachments, raw_msg):
+    r"""
+    BLAKE3 generator: uses lid and message source
+    Has 160 bit security
 
     Parameters:
     _msg - the parsed message (not used)
@@ -136,22 +77,21 @@ def dkim(_msg, _body, lid, _attachments, raw_msg):
     _attachments - list of attachments (not used)
     raw_msg - the original message bytes
 
-    Returns: str "<pibble>", a sixteen char custom base32 encoded hash
+    Returns: str "<blake3>", a 32 lower char custom base32 encoded digest
+
+    >>> blakey(None, None, "", None, b"")
+    'gj81364o27jfff9568s0v7pvfj6yy2oq'
     """
-    headers, body = rfc822_parse_dkim(raw_msg,
-                                      head_canon=True, body_canon=True,
-                                      head_subset=rfc4871_subset, archive_list_id=lid)
-    hashable = b"".join([h for header in headers for h in header])
-    if body:
-        hashable += b"\r\n" + body
-    # The pibble is the 80-bit SHA3-256 prefix
-    # It is base32 encoded using 0-9 a-z except [aeiu]
-    return pibble(hashable)
+    # The digest is 160 bits (i.e. 20 bytes)
+    digest: bytes = blake3_context_160(lid, raw_msg)
+    # The pibble32 encoded digest is 256 bits (i.e. 32 bytes)
+    # But still only has 160 bit security
+    return pibble32(digest)
 
 
 # Full generator: uses the entire email (including server-dependent data)
 # Used by default until August 2020.
-# See 'dkim' for recommended generation.
+# See 'blakey' for recommended generation.
 def full(msg, _body, lid, _attachments, _raw_msg):
     """
     Full generator: uses the entire email
@@ -175,7 +115,8 @@ def full(msg, _body, lid, _attachments, _raw_msg):
 
 
 __GENERATORS = {
-    'dkim': dkim,
+    'blakey': blakey,
+    'dkim': plugins.generators_old.dkim,
     'full': full,
     'medium': plugins.generators_old.medium,
     'cluster': plugins.generators_old.cluster,

--- a/tools/plugins/generators_old.py
+++ b/tools/plugins/generators_old.py
@@ -19,10 +19,12 @@
 This file contains the various older ID generators for Pony Mail's archivers.
 """
 
+import base64
 import hashlib
 import email.utils
-import time
 import re
+import time
+import typing
 
 
 # Medium: Standard 0.9 generator - Not recommended for future installations.
@@ -186,3 +188,126 @@ def legacy(msg, body, lid, _attachments, _raw_msg):
     mid = "%s@%s@%s" % (
     hashlib.sha224(body if type(body) is bytes else body.encode('utf-8', 'ignore')).hexdigest(), uid_mdate, lid)
     return mid
+
+# For optional nonce
+config: typing.Optional[dict] = None
+
+# Headers from RFC 4871, the precursor to RFC 6376
+rfc4871_subset = {
+    b"from", b"sender", b"reply-to", b"subject", b"date",
+    b"message-id", b"to", b"cc", b"mime-version", b"content-type",
+    b"content-transfer-encoding", b"content-id",
+    b"content-description", b"resent-date", b"resent-from",
+    b"resent-sender", b"resent-to", b"resent-cc",
+    b"resent-message-id", b"in-reply-to", b"references", b"list-id",
+    b"list-help", b"list-unsubscribe", b"list-subscribe",
+    b"list-post", b"list-owner", b"list-archive", b"dkim-signature"
+}
+
+# Authenticity headers from RFC 8617
+rfc4871_and_rfc8617_subset = rfc4871_subset | {
+    b"arc-authentication-results", b"arc-message-signature",
+    b"arc-seal"
+}
+
+
+def rfc822_parse_dkim(suffix,
+                      head_canon=False, body_canon=False,
+                      head_subset=None, archive_list_id=None):
+    headers = []
+    keep = True
+    list_ids = set()
+
+    while suffix:
+        # Edge case: headers don't end LF (add LF)
+        line, suffix = (suffix.split(b"\n", 1) + [b""])[:2]
+        if line in {b"\r", b""}:
+            break
+        end = b"\n" if line.endswith(b"\r") else b"\r\n"
+        if line[0] in {0x09, 0x20}:
+            # Edge case: starts with a continuation (treat like From)
+            if headers and (keep is True):
+                headers[-1][1] += line + end
+        elif not line.startswith(b"From "):
+            # Edge case: header start contains no colon (use whole line)
+            # "A field-name MUST be contained on one line." (RFC 822 B.2)
+            k, v = (line.split(b":", 1) + [b""])[:2]
+            k_lower = k.lower()
+            if k_lower == "list-id":
+                list_ids.add(k_lower)
+            if (head_subset is None) or (k_lower in head_subset):
+                keep = True
+                headers.append([k, v + end])
+            else:
+                keep = False
+    # The remaining suffix is the body
+    body = suffix.replace(b"\r\n", b"\n")
+    body = body.replace(b"\n", b"\r\n")
+
+    # Optional X-Archive-List-ID augmentation
+    if (archive_list_id is not None) and (archive_list_id not in list_ids):
+        xali_value = b" " + bytes(archive_list_id, "ascii")
+        headers.append([b"X-Archive-List-ID", xali_value])
+    # Optional nonce from local config
+    if config is not None:
+        if (config.get("archiver") and
+                config['archiver'].get('nonce')):
+            nonce = config['archiver'].get('nonce')
+            headers.append([b"X-Archive-Nonce", nonce])
+    # Optional head canonicalisation (DKIM relaxed)
+    if head_canon is True:
+        for i in range(len(headers)):
+            k, v = headers[i]
+            crlf = v.endswith(b"\r\n")
+            if crlf is True:
+                v = v[:-2]
+            v = v.replace(b"\r\n", b"")
+            v = v.replace(b"\t", b" ")
+            v = v.strip(b" ")
+            v = b" ".join(vv for vv in v.split(b" ") if vv)
+            if crlf is True:
+                v = v + b"\r\n"
+            headers[i] = [k.lower(), v]
+    # Optional body canonicalisation (DKIM simple)
+    if body_canon is True:
+        while body.endswith(b"\r\n\r\n"):
+            body = body[:-2]
+    return (headers, body)
+
+
+def pibble(hashable, size=10):
+    table = bytes.maketrans(
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZ234567",
+        b"0123456789bcdfghjklmnopqrstvwxyz",
+    )
+    digest = hashlib.sha3_256(hashable).digest()
+    prefix = digest[:size]
+    encoded = base64.b32encode(prefix)
+    return str(encoded.translate(table), "ascii")
+
+
+# DKIM generator: uses DKIM canonicalisation
+# Used by default
+def dkim(_msg, _body, lid, _attachments, raw_msg):
+    """
+    DKIM generator: uses DKIM relaxed/simple canonicalisation
+    We use the headers recommended in RFC 4871, plus DKIM-Signature
+
+    Parameters:
+    _msg - the parsed message (not used)
+    _body - the parsed text content (not used)
+    lid - list id
+    _attachments - list of attachments (not used)
+    raw_msg - the original message bytes
+
+    Returns: str "<pibble>", a sixteen char custom base32 encoded hash
+    """
+    headers, body = rfc822_parse_dkim(raw_msg,
+                                      head_canon=True, body_canon=True,
+                                      head_subset=rfc4871_subset, archive_list_id=lid)
+    hashable = b"".join([h for header in headers for h in header])
+    if body:
+        hashable += b"\r\n" + body
+    # The pibble is the 80-bit SHA3-256 prefix
+    # It is base32 encoded using 0-9 a-z except [aeiu]
+    return pibble(hashable)

--- a/tools/ponymail.yaml.example
+++ b/tools/ponymail.yaml.example
@@ -35,7 +35,7 @@ elasticsearch:
     #backup:                database name
 
 archiver:
-    #generator:             medium|full|cluster|dkim|other (dkim recommended)
+    #generator:             medium|full|cluster|blakey|dkim|other (blakey recommended)
     generator:              cluster
     # nonce:                optional secret salt ('pepper')
 


### PR DESCRIPTION
This PR adds a new generator called **blakey**, based on [BLAKE3](https://github.com/BLAKE3-team/BLAKE3). It deprecates the old **dkim** generator.

The new generator is fast and produces short output, at just 32 characters. It uses a deterministic, cryptographically secure hash of the conjunction of the `lid` and the raw message source received by `archiver.py`, with 160 bits of security. The encoding is the same as the dkim generator, which means it avoids the likelihood of taboo substrings.

The main difference between the new and old generators is that blakey does *not* attempt to deduplicate inputs. In other words, whereas the dkim generator was intended to simulate a DKIM signature session input, giving the same output for different message sources which were nevertheless regarded as equivalent according to the algorithm, the blakey generator is more like the **full** generator in that it generates a different output for every `lid` and message source pair.

The dkim generator was an early version of the one developed and discussed in [PR 517 of Ponymail](https://github.com/apache/incubator-ponymail/pull/517). That PR generated considerable disagreement as to the best method for judging two messages to be equivalent and encoding the result. There were several underlying problems, but the main one was the tension between wanting to deduplicate as thoroughly as possible by dropping information, and wanting to provide pristine archives by retaining information.

The blakey generator sidesteps this issue by retaining all information. The only benefit it shares in common with dkim is that the output is short and therefore better suited for shareable permalinks.

Since all information is retained in the new generator, naturally this means that input messages are no longer deduplicated. If this PR is accepted, the idea is that deduplication could instead occur as a separate process implemented either in `archiver.py` or in a background task. When a new message is received, existing messages could be checked for similarity. If a similar enough existing message is found, the new message can either be stored in the archive with a reference to the existing message, or discarded. Such a check would be quite efficient because, for example, the dkim generator considered messages with the same `message-id` to be equivalent, and a `message-id` query would dramatically narrow down the candidates to check for similarity. The interface can then redirect or ignore requests for messages that have a reference to an existing message.

This PR is, therefore, the first part in what could be a sequence of updates to Foal. This PR introduces blakey, and deprecates dkim. Next it would be useful to add a tool which would migrate databases using dkim to use blakey instead. Then various deduplication tools could be added, to `archiver.py` or as a background process, or both.

The significant advantage of this approach is that when deduplication takes place as a separate task with aliasing, it can not only be performed in a non-destructive way but it can also be flexible. The approach can be changed on the fly, and existing emails are unaffected. It does not require there to be a consensus on the difficult problem of what emails are equivalent. And it allows such approaches to be added incrementally.
