### PR TITLE
Fix imports in the scripts in tools

### DIFF
--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+from .archiver import *

--- a/tools/import-mbox.py
+++ b/tools/import-mbox.py
@@ -39,8 +39,12 @@ from threading import Lock, Thread
 from urllib.request import urlopen
 
 
-import archiver
-from plugins.elastic import Elastic
+if not __package__:
+    import archiver
+    from plugins.elastic import Elastic
+else:
+    from . import archiver
+    from .plugins.elastic import Elastic
 
 goodies = 0
 baddies = 0
@@ -565,7 +569,10 @@ if args.nomboxo:
 else:
     # Temporary patch to fix Python email package limitation
     # It must be removed when the Python package is fixed
-    from plugins.mboxo_patch import MboxoFactory, MboxoReader
+    if not __package__:
+        from plugins.mboxo_patch import MboxoFactory, MboxoReader
+    else:
+        from .plugins.mboxo_patch import MboxoFactory, MboxoReader
 
 if args.resend:
     resendTo = args.resend[0]

--- a/tools/migrate.py
+++ b/tools/migrate.py
@@ -2,7 +2,10 @@ import asyncio
 from elasticsearch import AsyncElasticsearch
 from elasticsearch.helpers import async_scan
 from elasticsearch import helpers
-import plugins.generators
+if not __package__:
+    from plugins import generators
+else:
+    from .plugins import generators
 import time
 import base64
 import hashlib
@@ -93,7 +96,7 @@ async def main():
         else:  # bytify
             source_text = source_text.encode('utf-8', 'ignore')
         if do_dkim:
-            dkim_id = plugins.generators.dkim(None, None, list_id, None, source_text)
+            dkim_id = generators.dkim(None, None, list_id, None, source_text)
             old_id = doc['_id']
             doc['_source']['mid'] = dkim_id
             doc['_source']['permalinks'] = [

--- a/tools/plugins/elastic.py
+++ b/tools/plugins/elastic.py
@@ -24,7 +24,7 @@ import sys
 import logging
 import certifi
 import os
-import plugins.ponymailconfig
+from . import ponymailconfig
 
 try:
     from elasticsearch import Elasticsearch, helpers
@@ -48,7 +48,7 @@ class Elastic:
 
     def __init__(self, dbname=None):
         # Fetch config
-        config = plugins.ponymailconfig.PonymailConfig()
+        config = ponymailconfig.PonymailConfig()
 
         # Set default names for all indices we use
         self.dbname = config.get('elasticsearch', 'dbname', fallback='ponymail')

--- a/tools/plugins/generators.py
+++ b/tools/plugins/generators.py
@@ -23,7 +23,8 @@ For older ID generators, see generators_old.py
 import base64
 import hashlib
 import typing
-import plugins.generators_old
+
+from . import generators_old
 
 # For optional nonce
 config: typing.Optional[dict] = None
@@ -177,9 +178,9 @@ def full(msg, _body, lid, _attachments, _raw_msg):
 __GENERATORS = {
     'dkim': dkim,
     'full': full,
-    'medium': plugins.generators_old.medium,
-    'cluster': plugins.generators_old.cluster,
-    'legacy': plugins.generators_old.legacy,
+    'medium': generators_old.medium,
+    'cluster': generators_old.cluster,
+    'legacy': generators_old.legacy,
 }
 
 

--- a/tools/push-failures.py
+++ b/tools/push-failures.py
@@ -21,9 +21,13 @@
 import argparse
 import json
 import os
-import plugins.elastic
 
-elastic = plugins.elastic.Elastic()
+if not __package__:
+    from plugins.elastic import Elastic
+else:
+    from .plugins.elastic import Elastic
+
+elastic = Elastic()
 
 parser = argparse.ArgumentParser(description="Command line options.")
 parser.add_argument(


### PR DESCRIPTION
The Python files in the `tools` directory are written to be run as scripts from that directory. This means that the `archiver.py` file doesn't work when installed as a package, which its own documentation advises, because it cannot find the `plugins` directory when imported as a package rather than run as a script.

The obvious solution to this is to change the `plugins` imports in `archiver.py` to be relative dotted imports, but this then causes `archiver.py` to fail when it is imported from the `import-mbox.py` script.

The problem is that Python [really doesn't like](https://stackoverflow.com/questions/16981921/relative-imports-in-python-3) files being used as both scripts and package modules. There have been many suggested workarounds for this over the years, with varying levels of complexity. This PR takes the [simple approach](https://stackoverflow.com/a/49480246) of using relative dotted imports only if `__package__` is set.

A more advanced solution would be to treat `tools` as a package which can be installed using pip. This would require much more effort, but would probably be easier for end users. In lieu of that, this PR also adds a simple `__init__.py` file which imports from `archiver.py`, so that installing `tools` as a package now only requires copying the whole directory instead of also copying `archiver.py` to `__init__.py`.
