### PR TITLE
Make dbid be a keyword

### DIFF
--- a/tools/mappings.yaml
+++ b/tools/mappings.yaml
@@ -55,6 +55,8 @@ mbox:
       format: yyyy/MM/dd HH:mm:ss
       store: true
       type: date
+    dbid:
+      type: keyword
     epoch:
       type: long
     from:


### PR DESCRIPTION
The ``dbid`` property of ``mbox`` objects is currently left to its default, i.e. text, but it should be keyword. This PR fixes that.
