### PR TITLE
Add thread info capabilities to the archiver

### DIFF
--- a/tools/mappings.yaml
+++ b/tools/mappings.yaml
@@ -59,6 +59,8 @@ mbox:
       type: keyword
     epoch:
       type: long
+    forum:
+      type: keyword
     from:
       type: text
     from_raw:
@@ -77,6 +79,8 @@ mbox:
       type: keyword
     permalinks:
       type: keyword
+    previous:
+      type: keyword
     private:
       type: boolean
     references:
@@ -84,8 +88,12 @@ mbox:
     subject:
       fielddata: true
       type: text
+    thread:
+      type: keyword
     to:
       type: text
+    top:
+      type: boolean
     _notes:
       type: text
     _archived_at:

--- a/tools/rethread.py
+++ b/tools/rethread.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+import archiver
+from elasticsearch.helpers import scan
+from plugins.elastic import Elastic
+
+
+def first_pass(elastic: Elastic) -> None:
+    hits = scan(
+        client=elastic.es,
+        index=elastic.db_mbox,
+        query={"sort": {"epoch": "asc"}},
+    )
+    for hit in hits:
+        pid = hit["_id"]
+        ojson = hit["_source"]
+        parent_info = archiver.get_parent_info(elastic, ojson)
+        ojson["top"] = parent_info is None
+        ojson["forum"] = ojson.get("list", "").strip("<>").replace(".", "@", 1)
+        source = elastic.es.get(
+            elastic.db_source, ojson["dbid"], _source="source"
+        )["_source"]["source"]
+        ojson["size"] = len(source)
+        ojson["previous"] = ""
+        ojson["thread"] = pid if (parent_info is None) else ""
+        elastic.index(index=elastic.db_mbox, id=pid, body=ojson)
+
+
+def second_pass(elastic: Elastic) -> None:
+    hits = scan(client=elastic.es, index=elastic.db_mbox, query={})
+    for hit in hits:
+        pid = hit["_id"]
+        ojson = hit["_source"]
+        if ojson["thread"] != "":
+            continue
+        if ojson["top"] is True:
+            ojson["previous"] = archiver.get_previous_mid(
+                elastic, ojson["forum"], ojson
+            )
+            ojson["thread"] = pid
+            elastic.index(index=elastic.db_mbox, id=pid, body=ojson)
+        else:
+            tree = []
+            while ojson["thread"] == "":
+                tree.append(ojson)
+                ojson_parent = archiver.get_parent_info(elastic, ojson)
+                if ojson_parent is None:
+                    ojson["previous"] = None
+                    print("Error:", ojson["mid"], "has no parent")
+                    break
+                ojson["previous"] = ojson_parent["mid"]
+                ojson = ojson_parent
+            for info in tree:
+                info["thread"] = ojson["thread"]
+                elastic.index(index=elastic.db_mbox, id=info["mid"], body=info)
+
+
+def main() -> None:
+    elastic: Elastic = Elastic()
+    first_pass(elastic)
+    second_pass(elastic)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR enables extra information about threads to be stored in elastic at archival time, rather than at UI time. In other words, instead of getting information about threads dynamically when people view a Foal powered website, information about threads is added to a message as soon as it is archived.

This mode is optional, and is enabled by setting `archiver.threadinfo` to `true` in the configuration file.

This PR includes a script called `rethread.py` which can add the information to an existing database. This means that an email archive which does not currently have archival time thread properties can be updated as a whole before changing how the archiver works.

One drawback to this approach is that if messages are received out of order then this may confuse the archiver. The `rethread.py` script can be used to fix such problems, but it does scan and modify the entire database to do so. It may be possible to have the script more selectively and carefully fix problems, but there is probably no getting around doing a full rescan.

The properties added to archived documents are `forum`, `previous`, `thread`, and `top`. The `forum` property is the email address of the mailing list, included as a handy alternative to `list_raw`. The `previous` property points to the mbox ID of either the parent message in the thread or, if the message is already the top of the thread, the top of the previous thread. The `thread` property points to the top of the current thread, which will be the same mbox ID as the current message if the current message is itself the top of the current thread. And the `top` property is a boolean indicating whether or not a message is the top of the current thread.
