### PR TITLE
Improve and document the thread info code

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -176,3 +176,27 @@ corresponding to a traceback in stderr.
 If the error ID is, for instance, `a06f7d4b-3a82-4ecf`, you can find the corresponding traceback
 by grepping your programs output. If you are running Foal as a systemd service, you could find 
 the traceback with: `journalctl --no-pager -u yourservicename | grep a06f7d4b-3a82-4ecf`
+
+## Archiving options
+To enable the storage in elasticsearch of extra properties related to
+threading, the following configuation snippet can be used in the
+`server/ponymail.yaml` file:
+~~~yaml
+archiver:
+  threadinfo: yes
+  threadparents: 10
+  threadtimeout: 5
+~~~
+The `threadparents` value limits the number of existing messages that
+will be queried for thread information at archive time when a new
+message is received. The `threadtimeout` value limits the duration of
+each query to elasticsearch.
+
+Enabling `threadinfo` means that `top`, `thread`, and `previous`
+properties will be added to each stored message. The `top` property is
+a boolean, indicating whether or not the message is the start of a new
+thread. The `thread` property gives the generated Foal ID of the top
+of the current thread; this will be the same as the ID of the current
+message if `top` is true. The `previous` property gives the generated
+Foal ID of either the most recent parent message if the message is not
+the top of a thread, or the top of the most recent thread otherwise.

--- a/tools/archiver.py
+++ b/tools/archiver.py
@@ -283,7 +283,7 @@ def get_parent_identifiers(ojson):
     return identifiers
 
 
-def get_by_message_id(elastic, msgid, timeout=5):
+def get_by_message_id(elastic, msgid, timeout="5s"):
     data = elastic.es.search(index=elastic.db_mbox, body={
         "query": {
             "bool": {
@@ -310,7 +310,7 @@ def get_parent_info(elastic, ojson, timeout=5, limit=10):
     return None
 
 
-def get_previous_mid(elastic, ojson, timeout=5):
+def get_previous_mid(elastic, ojson, timeout="5s"):
     forum = ojson["forum"]
     latest = ojson.get("epoch", 1) - 1
     data = elastic.es.search(index=elastic.db_mbox, body={
@@ -332,11 +332,11 @@ def get_previous_mid(elastic, ojson, timeout=5):
     return None
 
 
-def add_thread_properties(elastic, ojson, timeout=5, limit=5):
+def add_thread_properties(elastic, ojson, timeout="5s", limit=5):
     parent_info = get_parent_info(elastic, ojson, timeout, limit)
     if parent_info is None:
         top = True
-        thread = mid
+        thread = ojson["mid"]
         previous = get_previous_mid(elastic, ojson, timeout)
     else:
         top = False
@@ -651,6 +651,7 @@ class Archiver(object):  # N.B. Also used by import-mbox.py
         if config.get("archiver", "threadinfo"):
             try:
                 timeout = int(config.get("archiver", "threadtimeout") or 5)
+                timeout = str(timeout) + "s"
                 limit = int(config.get("archiver", "threadparents") or 10)
                 ojson = add_thread_properties(elastic, ojson, timeout, limit)
             except Exception as err:

--- a/tools/archiver.py
+++ b/tools/archiver.py
@@ -274,38 +274,44 @@ def message_identifiers(header, reverse=False):
 
 def get_parent_identifiers(ojson):
     identifiers = []
-    for irt in message_identifiers(ojson.get("in-reply-to", ""), reverse=True):
+    mirt = ojson.get("in-reply-to", "")
+    for irt in message_identifiers(mirt, reverse=True):
         identifiers.append(irt)
-    for ref in message_identifiers(ojson.get("references", ""), reverse=True):
+    mref = ojson.get("references", "")
+    for ref in message_identifiers(mref, reverse=True):
         identifiers.append(ref)
     return identifiers
 
 
-def get_by_message_id(elastic, msgid):
+def get_by_message_id(elastic, msgid, timeout=5):
     data = elastic.es.search(index=elastic.db_mbox, body={
         "query": {
             "bool": {
                 "must": {"term": {"message-id": msgid}}
             }
         }
-    })
+    }, timeout=timeout)
     if data["hits"]["total"]["value"] == 1:
         return data["hits"]["hits"][0]["_source"]
     return None
 
 
-def get_parent_info(elastic, ojson):
+def get_parent_info(elastic, ojson, timeout=5, limit=10):
     parent_identifiers = get_parent_identifiers(ojson)
     if not parent_identifiers:
         return None
     for parent_identifier in parent_identifiers:
-        parent_info = get_by_message_id(elastic, parent_identifier)
+        parent_info = get_by_message_id(elastic, parent_identifier, timeout)
         if parent_info is not None:
             return parent_info
+        limit -= 1
+        if limit < 1:
+            break
     return None
 
 
-def get_previous_mid(elastic, forum, ojson):
+def get_previous_mid(elastic, ojson, timeout=5):
+    forum = ojson["forum"]
     latest = ojson.get("epoch", 1) - 1
     data = elastic.es.search(index=elastic.db_mbox, body={
         "query": {
@@ -320,32 +326,26 @@ def get_previous_mid(elastic, forum, ojson):
         "sort": [{"epoch": "desc"}],
         "size": 1,
         "_source": "mid",
-    })
+    }, timeout=timeout)
     for hit in data["hits"]["hits"]:
         return hit["_source"]["mid"]
     return None
 
 
-def add_thread_properties(elastic, mid, ojson, size):
-    forum = ojson.get("list", "").strip("<>").replace(".", "@", 1)
-
-    parent_info = get_parent_info(elastic, ojson)
-
+def add_thread_properties(elastic, ojson, timeout=5, limit=5):
+    parent_info = get_parent_info(elastic, ojson, timeout, limit)
     if parent_info is None:
         top = True
         thread = mid
-        previous = get_previous_mid(elastic, forum, ojson)
+        previous = get_previous_mid(elastic, ojson, timeout)
     else:
         top = False
         thread = parent_info.get("thread")
         previous = parent_info["mid"]
 
-    ojson["forum"] = forum
-    ojson["previous"] = previous
-    ojson["size"] = size
-    ojson["thread"] = thread
     ojson["top"] = top
-
+    ojson["thread"] = thread
+    ojson["previous"] = previous
     return ojson
 
 
@@ -590,6 +590,8 @@ class Archiver(object):  # N.B. Also used by import-mbox.py
                 "body": body.unflow() if body else "",
                 "html_source_only": body and body.html_as_source or False,
                 "attachments": attachments,
+                "forum": (lid or "").strip("<>").replace(".", "@", 1),
+                "size": len(raw_msg),
                 "_notes": notes,
                 "_archived_at": int(time.time()),
             }
@@ -648,7 +650,9 @@ class Archiver(object):  # N.B. Also used by import-mbox.py
 
         if config.get("archiver", "threadinfo"):
             try:
-                ojson = add_thread_properties(elastic, ojson["mid"], ojson, len(raw_message))
+                timeout = int(config.get("archiver", "threadtimeout") or 5)
+                limit = int(config.get("archiver", "threadparents") or 10)
+                ojson = add_thread_properties(elastic, ojson, timeout, limit)
             except Exception as err:
                 print("Could not add thread info", err)
                 if logger:

--- a/tools/mappings.yaml
+++ b/tools/mappings.yaml
@@ -85,6 +85,8 @@ mbox:
       type: boolean
     references:
       type: text
+    size:
+      type: long
     subject:
       fielddata: true
       type: text

--- a/tools/plugins/elastic.py
+++ b/tools/plugins/elastic.py
@@ -44,6 +44,7 @@ class Elastic:
     db_session:         str
     db_notification:    str
     db_mailinglist:     str
+    db_auditlog:        str
 
     def __init__(self):
         # Fetch config

--- a/tools/rethread.py
+++ b/tools/rethread.py
@@ -1,11 +1,48 @@
 #!/usr/bin/env python3
 
-import archiver
 from elasticsearch.helpers import scan
+
+import archiver
 from plugins.elastic import Elastic
 
 
 def first_pass(elastic: Elastic) -> None:
+    hits = scan(
+        client=elastic.es,
+        index=elastic.db_mbox,
+        # Thanks to elasticsearch_dsl.Q
+        # (~Q(...)) | (~Q(...))
+        query={
+            "query": {
+                "bool": {
+                    "should": [
+                        {
+                            "bool": {
+                                "must_not": [{"exists": {"field": "forum"}}]
+                            }
+                        },
+                        {
+                            "bool": {
+                                "must_not": [{"exists": {"field": "size"}}]
+                            }
+                        },
+                    ]
+                }
+            }
+        },
+    )
+    for hit in hits:
+        pid = hit["_id"]
+        ojson = hit["_source"]
+        ojson["forum"] = ojson.get("list", "").strip("<>").replace(".", "@", 1)
+        source = elastic.es.get(
+            elastic.db_source, ojson["dbid"], _source="source"
+        )["_source"]["source"]
+        ojson["size"] = len(source)
+        elastic.index(index=elastic.db_mbox, id=pid, body=ojson)
+
+
+def second_pass(elastic: Elastic) -> None:
     hits = scan(
         client=elastic.es,
         index=elastic.db_mbox,
@@ -16,17 +53,12 @@ def first_pass(elastic: Elastic) -> None:
         ojson = hit["_source"]
         parent_info = archiver.get_parent_info(elastic, ojson)
         ojson["top"] = parent_info is None
-        ojson["forum"] = ojson.get("list", "").strip("<>").replace(".", "@", 1)
-        source = elastic.es.get(
-            elastic.db_source, ojson["dbid"], _source="source"
-        )["_source"]["source"]
-        ojson["size"] = len(source)
         ojson["previous"] = ""
         ojson["thread"] = pid if (parent_info is None) else ""
         elastic.index(index=elastic.db_mbox, id=pid, body=ojson)
 
 
-def second_pass(elastic: Elastic) -> None:
+def third_pass(elastic: Elastic) -> None:
     hits = scan(client=elastic.es, index=elastic.db_mbox, query={})
     for hit in hits:
         pid = hit["_id"]
@@ -34,9 +66,7 @@ def second_pass(elastic: Elastic) -> None:
         if ojson["thread"] != "":
             continue
         if ojson["top"] is True:
-            ojson["previous"] = archiver.get_previous_mid(
-                elastic, ojson["forum"], ojson
-            )
+            ojson["previous"] = archiver.get_previous_mid(elastic, ojson)
             ojson["thread"] = pid
             elastic.index(index=elastic.db_mbox, id=pid, body=ojson)
         else:
@@ -59,6 +89,7 @@ def main() -> None:
     elastic: Elastic = Elastic()
     first_pass(elastic)
     second_pass(elastic)
+    third_pass(elastic)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Resolves #49.

This PR moves the `forum` and `size` properties to the standard Foal database entry for an archived email. The existing code for `top`, `previous`, and `thread` from #43 is retained, but improved: two new `threadparents` and `threadtimeout` properties bound the execution time of querying the new properties. The addition of these properties is optional, and is off by default. The documentation now explains their usage.
