### PR TITLE
Convert mbox endpoint to a streaming response

### DIFF
--- a/server/endpoints/mbox.py
+++ b/server/endpoints/mbox.py
@@ -27,7 +27,7 @@ import aiohttp.web
 import asyncio.exceptions
 
 
-async def convert_source(session, email):
+async def convert_source(session: plugins.session.SessionObject, email: dict):
     source = await plugins.messages.get_source(session, permalink=email.get("dbid", email["mid"]))
     if source:
         source_as_text = source["_source"]["source"]

--- a/server/endpoints/mbox.py
+++ b/server/endpoints/mbox.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 """Endpoint for returning emails in mbox format as a single archive"""
+import asyncio
 import plugins.server
 import plugins.session
 import plugins.messages
@@ -23,48 +24,71 @@ import plugins.defuzzer
 import re
 import typing
 import aiohttp.web
+import asyncio.exceptions
+
+
+async def convert_source(session, email):
+    source = await plugins.messages.get_source(session, permalink=email.get("dbid", email["mid"]))
+    if source:
+        source_as_text = source["_source"]["source"]
+        # Convert to mboxrd format
+        mboxrd_source = ""
+        line_no = 0
+        for line in source_as_text.split("\n"):
+            line_no += 1
+            if line_no > 1 and re.match(r"^>*From\s+", line):
+                line = ">" + line
+            mboxrd_source += line + "\n"
+        return mboxrd_source
+    return ""
 
 
 async def process(
-    server: plugins.server.BaseServer, session: plugins.session.SessionObject, indata: dict,
-) -> typing.Union[dict, aiohttp.web.Response]:
+    server: plugins.server.BaseServer,
+    request: aiohttp.web.BaseRequest,
+    session: plugins.session.SessionObject,
+    indata: dict,
+) -> typing.Union[dict, aiohttp.web.Response, aiohttp.web.StreamResponse]:
 
     lid = indata.get("list", "_")
     domain = indata.get("domain", "_")
-    
+
     try:
         query_defuzzed = plugins.defuzzer.defuzz(indata, list_override="@" in lid and lid or None)
     except AssertionError as e:  # If defuzzer encounters syntax errors, it will throw an AssertionError
-        return aiohttp.web.Response(headers={"content-type": "text/plain",}, status=500, text=str(e))
-    results = await plugins.messages.query(session, query_defuzzed, query_limit=server.config.database.max_hits,)
-
-    sources = []
-    for email in results:
-        source = await plugins.messages.get_source(session, permalink=email.get("dbid", email["mid"]))
-        if source:
-            stext = source["_source"]["source"]
-            # Convert to mboxrd format
-            mboxrd_source = ""
-            line_no = 0
-            for line in stext.split("\n"):
-                line_no += 1
-                if line_no > 1 and re.match(r"^>*From\s+", line):
-                    line = ">" + line
-                mboxrd_source += line + "\n"
-            sources.append(mboxrd_source)
+        return aiohttp.web.Response(
+            headers={
+                "content-type": "text/plain",
+            },
+            status=500,
+            text=str(e),
+        )
+    results = await plugins.messages.query(
+        session,
+        query_defuzzed,
+        query_limit=server.config.database.max_hits,
+    )
 
     # Figure out a sane filename
     xlist = re.sub(r"[^-_.a-z0-9]+", "_", lid)
     xdomain = re.sub(r"[^-_.a-z0-9]+", "_", domain)
     dlfile = f"{xlist}-{xdomain}.mbox"
+    headers = {"Content-Type": "application/mbox", "Content-Disposition": f"attachment; filename={dlfile}"}
 
-    # Return mbox archive with filename
-    return aiohttp.web.Response(
-        headers={"Content-Type": "application/mbox", "Content-Disposition": f"attachment; filename={dlfile}",},
-        status=200,
-        text="\n\n".join(sources),
-    )
+    # Return mbox archive with filename as a stream
+    response = aiohttp.web.StreamResponse(status=200, headers=headers)
+    response.enable_chunked_encoding()
+    await response.prepare(request)
+    for email in results:
+        mboxrd_source = await convert_source(session, email)
+        try:
+            async with server.streamlock:
+                await asyncio.wait_for(response.write(mboxrd_source.encode("utf-8")), timeout=5)
+        except (TimeoutError, RuntimeError, asyncio.exceptions.CancelledError):
+            break  # Writing stream failed, break it off.
+    return response
 
 
 def register(server: plugins.server.BaseServer):
-    return plugins.server.Endpoint(process)
+    # Note that this is a StreamingEndpoint!
+    return plugins.server.StreamingEndpoint(process)

--- a/server/main.py
+++ b/server/main.py
@@ -24,6 +24,7 @@ import json
 import os
 import sys
 import traceback
+import typing
 
 import aiohttp.web
 import yaml
@@ -83,7 +84,7 @@ class Server(plugins.server.BaseServer):
 
     async def handle_request(
         self, request: aiohttp.web.BaseRequest
-    ) -> aiohttp.web.Response:
+    ) -> typing.Union[aiohttp.web.Response, aiohttp.web.StreamResponse]:
         """Generic handler for all incoming HTTP requests"""
 
         # Define response headers first...

--- a/server/main.py
+++ b/server/main.py
@@ -62,6 +62,7 @@ class Server(plugins.server.BaseServer):
         self.dbpool = asyncio.Queue()
         self.runners = plugins.offloader.ExecutorPool()
         self.server = None
+        self.streamlock = asyncio.Lock()
 
         # Make a pool of 15 database connections for async queries
         for _ in range(1, 15):

--- a/server/main.py
+++ b/server/main.py
@@ -115,10 +115,11 @@ class Server(plugins.server.BaseServer):
                 # Wait for endpoint response. This is typically JSON in case of success,
                 # but could be an exception (that needs a traceback) OR
                 # it could be a custom response, which we just pass along to the client.
-                if isinstance(handler, plugins.server.StreamingEndpoint):
-                    output = await handler.exec(self, request, session, indata)
-                elif isinstance(handler, plugins.server.Endpoint):
-                    output = await handler.exec(self, session, indata)
+                xhandler = self.handlers[handler]
+                if isinstance(xhandler, plugins.server.StreamingEndpoint):
+                    output = await xhandler.exec(self, request, session, indata)
+                elif isinstance(xhandler, plugins.server.Endpoint):
+                    output = await xhandler.exec(self, session, indata)
                 if session.database:
                     self.dbpool.put_nowait(session.database)
                     self.dbpool.task_done()

--- a/server/plugins/server.py
+++ b/server/plugins/server.py
@@ -34,6 +34,13 @@ class Endpoint:
         self.exec = executor
 
 
+class StreamingEndpoint:
+    exec: typing.Callable
+
+    def __init__(self, executor):
+        self.exec = executor
+
+
 class BaseServer:
     """Main server class, base def"""
 
@@ -44,3 +51,4 @@ class BaseServer:
     database: AsyncElasticsearch
     dbpool: asyncio.Queue
     runners: plugins.offloader.ExecutorPool
+    streamlock: asyncio.Lock


### PR DESCRIPTION
Currently, the mbox endpoint gathers up all emails and generates an mbox file before it is sent.
When you have thousands of emails, this can be several if not hundreds of megabytes that may be for nothing, if the download fails. Instead, converting it to a streaming response, where emails are fetched as chunks, will lower the memory and processing footprint of the endpoint. Should a stream fail while it is in flight, the remainder of the conversions can then safely be canceled.