### PR TITLE
Look for dates on envelope and in headers if Date is missing or invalid

### DIFF
--- a/tools/archiver.py
+++ b/tools/archiver.py
@@ -424,7 +424,7 @@ class Archiver(object):  # N.B. Also used by import-mbox.py
         msg: email.message.Message,
         raw_msg: bytes,
         default_date: typing.Union[None, str, int] = None
-    ) -> typing.Tuple[typing.Optional[dict], dict, dict, typing.Optional[str]]:
+    ) -> typing.Tuple[typing.Optional[dict], dict, dict, typing.Optional[str], bool]:
         """Determine what needs to be sent to the archiver.
         :param lid: The list id
         :param private: Whether privately archived email or not (bool)

--- a/tools/archiver.py
+++ b/tools/archiver.py
@@ -516,8 +516,10 @@ class Archiver(object):  # N.B. Also used by import-mbox.py
                     else:
                         print("Could not find any valid dates in email headers, using --defaultdate parameter %s" % default_date)
                         epoch = int(default_date)
+                        notes.append(["BADDATE: Falling back to default epoch specified by --defaultdate: %s" % default_date])
                 else:
                     print("Could not find any valid dates in email headers, using current time")
+                    notes.append(["BADDATE: Falling back to default UNIX epoch"])
                     epoch = time.time()
             else:
                 epoch = email.utils.mktime_tz(message_date)

--- a/tools/archiver.py
+++ b/tools/archiver.py
@@ -512,7 +512,7 @@ class Archiver(object):  # N.B. Also used by import-mbox.py
                 # If --defaultdate is defined, use that instead.
                 if default_date is not None:
                     if default_date == "skip":  # If we are to skip emails with bad dates...
-                        return {"foo": "bar"}, None, None, None, True  # return fake set with skipit == True
+                        return {"foo": "bar"}, {}, {}, None, True  # return fake set with skipit == True
                     else:
                         print("Could not find any valid dates in email headers, using --defaultdate parameter %s" % default_date)
                         epoch = int(default_date)

--- a/tools/archiver.py
+++ b/tools/archiver.py
@@ -53,7 +53,6 @@ import time
 import traceback
 import typing
 import uuid
-import datetime
 
 import elasticsearch
 import formatflowed

--- a/tools/archiver.py
+++ b/tools/archiver.py
@@ -520,11 +520,11 @@ class Archiver(object):  # N.B. Also used by import-mbox.py
                 else:
                     print("Could not find any valid dates in email headers, using current time")
                     notes.append(["BADDATE: Falling back to default UNIX epoch"])
-                    epoch = time.time()
+                    epoch = int(time.time())
             else:
-                epoch = email.utils.mktime_tz(message_date)
+                epoch = int(email.utils.mktime_tz(message_date))
         else:
-            epoch = email.utils.mktime_tz(message_date)
+            epoch = int(email.utils.mktime_tz(message_date))
         # message_date calculations are all done, prepare the index entry
         date_as_string = time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(epoch))
         body = self.message_body(msg)


### PR DESCRIPTION
This expands the way we deal with missing or ínvalid date headers, by:
- looking for an envelope From header, and if possible, using the date from there
- if no valid From envelope, search the Received headers for a useful date
- if still nothing, fall back to current time and date.

This should address #56. I've tested with emails missing all three fields (sets to NOW), the Date field only (uses the From envelope header), and missing both Date and FROM (uses Received headers then).