### PR TITLE
Made Readme bullet points cleaner

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,25 +16,25 @@ a pure python version of Apache Pony Mail with support for ElasticSearch
 ## New features in Foal:
 Among other things, Foal sports the following new features:
 
-- Improved archiver and import tools
-- New, sleeker UI for the end user
-- Migration tools for moving to Foal
-- 100% python backend, no Lua required
-- In-place editing of emails via web UI
+* Improved archiver and import tools
+* New, sleeker UI for the end user
+* Migration tools for moving to Foal
+* 100% python backend, no Lua required
+* In-place editing of emails via web UI
 
 ## Installation Guide
 Please see the [installation documentation](INSTALL.md) for setup instructions.
 
 ### Current setup requirements:
 
-- An operating system, such as:
-- - Linux
-- - FreeBSD
-- - Windows
-- - Mac OS
-- Python 3.7.3 or higher with dependencies from `requirements.txt` in tools/ and server/ as needed.
-- Web server with proxy capabilities for the UI.
-- ElasticSearch 7.x or higher.
+* An operating system, such as:
+  * Linux
+  * FreeBSD
+  * Windows
+  * Mac OS
+* Python 3.7.3 or higher with dependencies from `requirements.txt` in tools/ and server/ as needed.
+* Web server with proxy capabilities for the UI.
+* ElasticSearch 7.x or higher.
 
 
 ### Migration disclaimer:


### PR DESCRIPTION
Made the nested bullet points in the Readme.md in a single form and not doubled. To avoid confusion make all the bullet points in a single * format rather than - format.
