### PR TITLE
Fix bug causing dedup to fail when importing mailboxes

### DIFF
--- a/tools/import-mbox.py
+++ b/tools/import-mbox.py
@@ -327,7 +327,7 @@ class SlurpThread(Thread):
                             }
                         },
                     )
-                    if res and len(res["hits"]["total"]) > 0:
+                    if res and res["hits"]["total"]["value"] > 0:
                         self.printid(
                             "Dedupping %s - matched in %s"
                             % (

--- a/tools/import-mbox.py
+++ b/tools/import-mbox.py
@@ -327,7 +327,7 @@ class SlurpThread(Thread):
                             }
                         },
                     )
-                    if res and res["hits"]["total"] > 0:
+                    if res and len(res["hits"]["total"]) > 0:
                         self.printid(
                             "Dedupping %s - matched in %s"
                             % (


### PR DESCRIPTION
Using import-mbox.py with --dedup would fail on python 3.8 due to this invalid comparison