### PR TITLE
Faster code to clean up quotes

### DIFF
--- a/webui/js/source/body-fixups.js
+++ b/webui/js/source/body-fixups.js
@@ -270,7 +270,7 @@ function fixup_quotes(splicer) {
             quote = m[0];
             i = quote.length;
             t = splicer.substr(0, i);
-            quote = quote.replace(/(>*\s*\r?\n)+$/g, "");
+            quote = quote.replace(/\n>[>\s]*$/g, "\n");
             qdiv = new HTML('div', {
                 "class": "email_quote_parent"
             }, [


### PR DESCRIPTION
Right now the `*` in the regex to clean up quotes makes it rather slow for large quoted texts. With this change it is slightly less 'precise' but much faster, which might be a reasonable trade-off in this case?

You can reproduce at https://regexr.com/ by adding 50 or so newlines to the example input.

The effect in Pony Mail is that such emails cannot be opened at all, but produce some javascript error.