### PR TITLE
Add an ability to ignore bad content-type headers

### DIFF
--- a/tools/archiver.py
+++ b/tools/archiver.py
@@ -211,6 +211,11 @@ class Body:
                         break
                     except UnicodeDecodeError:
                         pass
+                    except:
+                        if not bool(config.get("debug","ignore_bad_contenttype", False)):
+                            raise
+                        print(f"Ignoring bad Content-Type: {cs}")
+                        pass
             # If no character set was defined, the email MUST be US-ASCII by RFC822 defaults
             # This isn't always the case, as we're about to discover.
             if not self.string:

--- a/tools/archiver.yaml.example
+++ b/tools/archiver.yaml.example
@@ -44,3 +44,4 @@ debug:
     #cropout:               string to crop from list-id
     # e.g. Strip out incubator except at top level
     # cropout:                (\w+\.\w+)\.incubator\.apache\.org \1.apache.org
+    #ignore_bad_contenttype:  true # try default content types if email has an invalid one rather than failing


### PR DESCRIPTION
Instead of failing on them. A fair number of emails in the wild have bad headers so just try the default ones instead if this option is set.

Example:

[mjc10-sanitised.mbox.txt](https://github.com/apache/incubator-ponymail-foal/files/11088256/mjc10-sanitised.mbox.txt)

