### PR TITLE
Allow messages with no text or HTML body and no attachments.

### DIFF
--- a/tools/archiver.py
+++ b/tools/archiver.py
@@ -408,6 +408,7 @@ class Archiver(object):  # N.B. Also used by import-mbox.py
         """
         body = None
         first_html = None
+        last_random = None
         for part in msg.walk():
             # can be called from importer
             if self.verbose:
@@ -427,8 +428,18 @@ class Archiver(object):  # N.B. Also used by import-mbox.py
                     and part.get_content_type() == "text/html"
                 ):
                     first_html = Body(part)
+                elif (
+                    body is None
+                ):
+                    last_random = Body(part)
             except Exception as err:
                 print(err)
+
+
+        if last_random and not first_html and body is None:
+            if bool(config.get("debug","allow_nontext_body", False)):
+                print("No text or html body found, using what we have")
+                body = last_random
 
         # this requires a GPL lib, user will have to install it themselves
         if first_html and (

--- a/tools/archiver.yaml.example
+++ b/tools/archiver.yaml.example
@@ -44,3 +44,4 @@ debug:
     #cropout:               string to crop from list-id
     # e.g. Strip out incubator except at top level
     # cropout:                (\w+\.\w+)\.incubator\.apache\.org \1.apache.org
+    #allow_nontext_body:      true # accept messages that have no html or text body


### PR DESCRIPTION
These are fairly common for example a calendar entry might be sent as "Content-Type: text/calendar".  I just made it so that if there is no recognised body it just uses whatever the last section it found was, regardless of content type.

Example:
[mjc11a-sanitised.mbox.txt](https://github.com/apache/incubator-ponymail-foal/files/11088351/mjc11a-sanitised.mbox.txt)
