### PR TITLE
Add an option useful for personal email archiving

### DIFF
--- a/tools/archiver.py
+++ b/tools/archiver.py
@@ -466,6 +466,24 @@ class Archiver(object):  # N.B. Also used by import-mbox.py
         """
         notes = []  # Put debug notes in here, for later...
 
+        allow_lid = config.get("list-id","allow")
+        deny_lid = config.get("list-id","ignore")
+        mlid = msg.get("list-id")
+        deny = False; allow = False;
+        # If our list id is on the allow list leave it be, otherwise set it to the default
+        # For a dry run display the list id's that are not allowed and not denied
+
+        if mlid:
+            mlidtext = textlib.normalize_lid(mlid)
+            if mlidtext:
+                if deny_lid:
+                    deny = any(x in mlidtext.lower() for x in deny_lid.split(','))
+                if (not deny and allow_lid):
+                    allow = any(x in mlidtext.lower() for x in allow_lid.split(','))
+                    if allow:
+                        lid = mlidtext
+                if allow_lid and not allow and not deny:
+                    print(f"New-list-ID {mlidtext}")
         if not lid:
             lid = textlib.normalize_lid(msg.get("list-id"), strict=True)
             if lid is None:

--- a/tools/archiver.yaml.example
+++ b/tools/archiver.yaml.example
@@ -44,3 +44,11 @@ debug:
     #cropout:               string to crop from list-id
     # e.g. Strip out incubator except at top level
     # cropout:                (\w+\.\w+)\.incubator\.apache\.org \1.apache.org
+
+list-id:
+    # allow:                list of lower case strings that if found in the list-id do not get replaced by our default
+    #  e.g.
+    #  allow:                 apache.org,yahoogroups.com
+    # ignore:               list of lower case strings that if found in the list-id we ignore (no replacement, no message)
+    #  e.g.
+    #  ignore:                xt.local,mcsv.net


### PR DESCRIPTION
Handling List-Id's.  Ponymail likes to sort mails by the List-Id which makes a lot of sense where you have the thousands of Apache lists.  But with personal email, and certainly when you subscribe to various newsletters, or get bills, or spam that got into the archives then you end up with lots of list id's that are only used once or twice or are not useful.  Working on open source projects there's lots of lists that I'm on that I want the email to get archived, but it would be nice if it was separated out in the Ponymail UI.  So really I needed the ability to have an 'allow list' of list id's that I want to have separate, with everything else defaulting to a generic list id (being my email address where all those mails came into).

If you run with an allow: list and run import-mbox with a --lid default then all list-ids will be replaced by your --lid default unless they match the text substring in the allow list.  All other list ids are displayed (so you can do a dry run and spot which you'd like on the allow list).  Any on the ignore list are not printed, nothing else is done with them, it's just so you can get a smaller list of unknown list-ids displayed to decide which to add to your allow list.

Ponymail might not want to integrate this feature, or do it in a different way, but opening a PR to capture the patch and comments.