### PR TITLE
Add the packaging dependency to server/requirements.txt

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -12,3 +12,4 @@ google-auth~=2.38.0              # AL2.0
 aiosmtplib~=4.0.0                # MIT
 python-dateutil                  # BSD, AL2.0
 types-python-dateutil            # BSD, AL2.0
+packaging~=24.2                  # BSD, AL2.0


### PR DESCRIPTION
This should solve issue #281 by providing the `packaging` pip during the image build process.