### PR TITLE
Add long-term API tokens for programmatic authentication (#312)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ server/
 │   ├── compose.py             # Send email (authenticated)
 │   ├── preferences.py         # User prefs + list overview
 │   ├── mgmt.py                # Admin GDPR operations
+│   ├── token.py               # Long-term API token management (create/list/revoke)
 │   ├── oauth.py               # OAuth login flow
 │   ├── pminfo.py              # Server activity info
 │   ├── gravatar.py            # Avatar caching proxy
@@ -37,13 +38,14 @@ server/
 │   ├── configuration.py       # YAML config parsing (source of truth for all config keys)
 │   ├── database.py            # ElasticSearch async client pool
 │   ├── messages.py            # Email query, threading, trimming logic
-│   ├── session.py             # Cookie-based sessions + OAuth credential tracking
+│   ├── session.py             # Cookie sessions + API token auth + OAuth credential tracking
 │   ├── aaa.py                 # Access control (public vs private lists)
 │   ├── defuzzer.py            # Date/query parameter normalization
-│   ├── background.py          # Periodic index refresh tasks
+│   ├── background.py          # Periodic index refresh + expired-token purge
 │   ├── formdata.py            # Request body parsing (form vs JSON)
 │   ├── offloader.py           # Thread pool for CPU-bound JSON serialization
 │   ├── auditlog.py            # Admin action logging
+│   ├── token.py               # API token generation, hashing, scopes, expiry
 │   └── oauth*.py              # Provider-specific OAuth token exchange
 └── testendpoints/             # Extra endpoints loaded with --testendpoints
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -21,7 +21,9 @@ This document describes the HTTP API for Pony Mail Foal. All endpoints
 accept JSON request bodies (POST) and return JSON unless otherwise noted.
 
 The formal OpenAPI 3.0 specification is available at
-[`server/openapi.yaml`](../server/openapi.yaml).
+[`server/openapi.yaml`](../server/openapi.yaml). You can auto-generate a typed
+client library in most languages from it rather than hand-writing one — see
+[Generating API Client Libraries](generating_api_clients.md).
 
 ---
 
@@ -36,6 +38,7 @@ The formal OpenAPI 3.0 specification is available at
   - [mbox.json — Download mbox archive](#mboxjson)
   - [compose.json — Send an email](#composejson)
   - [preferences.json — User preferences and list overview](#preferencesjson)
+  - [token.json — Long-term API tokens](#tokenjson)
   - [mgmt.json — Administrative operations](#mgmtjson)
   - [pminfo.json — Server activity info](#pminfojson)
   - [gravatar.json — Avatar image proxy](#gravatarjson)
@@ -49,10 +52,36 @@ The formal OpenAPI 3.0 specification is available at
 
 ## Authentication
 
-Foal uses cookie-based sessions via OAuth. The session cookie is named
-`ponymail`. Most read endpoints work without authentication for public
-lists. Private list access and write operations (compose, management)
-require an authenticated session via an authoritative OAuth provider.
+Foal supports two ways of authenticating API requests:
+
+1. **Cookie session (interactive).** Foal uses cookie-based sessions via OAuth.
+   The session cookie is named `ponymail`. This is what the web UI uses.
+2. **Long-term API token (programmatic).** Send an `Authorization: Bearer <token>`
+   header. Tokens are ideal for scripts and automation: they are not subject to
+   the short session-cookie lifetime and never require a browser round-trip. A
+   token grants access up to that of the account that created it (including any
+   private lists that account can reach), further limited by the token's
+   [scopes](#scopes). Create and manage tokens via
+   [`token.json`](#tokenjson) or the **API Tokens** entry in the web UI's user
+   menu.
+
+Most read endpoints work without authentication for public lists. Private list
+access and write operations (compose, management) require an authenticated
+session (cookie or token) via an authoritative OAuth provider.
+
+If a request presents a bearer token that is invalid, revoked, or expired, the
+server responds with **`403`** and `{"okay": false, "message": "Invalid or
+expired API token."}` — it does **not** silently fall back to anonymous access,
+so a client can detect the condition and refresh its credentials. (A token that
+is merely missing a required [scope](#scopes) gets `403` with a different
+message.)
+
+Example using a token:
+
+```
+curl -H "Authorization: Bearer pmt_XXXXXXXX..." \
+     "https://lists.example.org/api/mbox.json?list=dev@example.org&date=2024-01"
+```
 
 ---
 
@@ -320,6 +349,109 @@ POST /api/preferences.json
 
 ---
 
+### token.json
+
+**Create, list, and revoke long-term API tokens for the logged-in user.**
+
+```
+POST /api/token.json
+```
+
+Requires an interactive (cookie) session — tokens cannot be managed using token
+authentication. The raw token secret is returned **only once**, at creation
+time; the server stores only a hash of it.
+
+`list` is the default action. `create` and `revoke` must be sent as actions in a
+JSON POST body; mutation actions in query parameters are rejected.
+
+#### Request Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | string | no | One of `list` (default), `create`, `revoke` |
+| `description` | string | no | (`create`) Human-readable label for the token |
+| `scopes` | string/list | no | (`create`) Scopes to grant (space/comma-separated or a JSON list). Defaults to `read`. |
+| `lifetime` | integer | no | (`create`) Lifetime in seconds; `0` = never expires. Defaults to the server's configured default (30 days). Clamped to the server maximum if one is set. |
+| `id` | string | no | (`revoke`) Id of the token to revoke |
+
+#### Scopes
+
+A token's effective access is the **intersection** of its owner's account
+permissions and its scopes — a scope can only *restrict* access, never grant
+more than the account already has. A request with a token that lacks the
+required scope for an endpoint gets `403`.
+
+| Scope | Grants | Endpoints |
+|-------|--------|-----------|
+| `read` | Read the archives (search, fetch emails/threads/sources, download mbox, preferences) | `stats`, `email`, `thread`, `source`, `mbox`, `preferences`, `pminfo`, `gravatar`, `plain` |
+| `write` | Send email | `compose` |
+| `admin` | Administrative operations (hide/delete/edit) — only effective for admin accounts | `mgmt` |
+
+A scope is a **wish, not a stored grant.** The server does *not* snapshot the
+owner's permissions into the token when it is created. On **every** request it
+recomputes the effective access as the intersection of the token's scopes with
+the owner's **current** account permissions, resolved live from the account
+record at that moment. Two consequences follow:
+
+- If the owner **loses** a permission (removed from a private list, or their
+  admin/moderator status is dropped), every existing token immediately loses
+  that access on its next request — regardless of the scope it was minted with.
+  A token is therefore *not* a cached copy of permissions that could go stale;
+  there is nothing to invalidate or evict when permissions shrink.
+- If the owner **gains** a permission after a token was created, a token whose
+  scope already covers it starts working for the newly reachable resource
+  automatically, with no need to re-issue the token.
+
+The `admin` scope illustrates this: it only ever grants administrative access
+while the underlying account is *currently* an admin (see the
+[`oauth.admins`](configuration.md#oauth) list) — minting an `admin`-scoped
+token does not make a non-admin an admin, and an admin who is later removed
+from `oauth.admins` loses admin access through all of their tokens at once.
+
+Revoking a token (`action=revoke`) remains the way to kill one *specific*
+credential (for example a leaked one); reducing what the *account* itself can
+do is handled entirely by the live intersection above. To forcibly cut off
+**all** of a user's tokens at once — e.g. after their upstream credentials are
+reset — an administrator can use [`mgmt.json`](#mgmtjson)'s `token_purge`
+action.
+
+#### Response
+
+`action=create` (the only time the raw `token` is shown):
+
+```json
+{
+  "okay": true,
+  "id": "3f9a...c1",
+  "description": "laptop backup script",
+  "created": 1717977600,
+  "expires": 1720569600,
+  "last_used": 0,
+  "scopes": ["read"],
+  "token": "pmt_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+}
+```
+
+`action=list`:
+
+```json
+{
+  "okay": true,
+  "tokens": [
+    {"id": "3f9a...c1", "description": "laptop backup script", "scopes": ["read"],
+     "created": 1717977600, "expires": 1720569600, "last_used": 1718000000}
+  ]
+}
+```
+
+**Notes:**
+- Use a token by sending `Authorization: Bearer <token>` on any API request
+  (see [Authentication](#authentication)).
+- Token management is disabled when `tokens.enabled` is `false` in
+  `ponymail.yaml`.
+
+---
+
 ### mgmt.json
 
 **Administrative endpoint for email management (GDPR operations).**
@@ -333,12 +465,14 @@ POST /api/mgmt.json
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `action` | string | **yes** | One of: `log`, `delete`, `hide`, `unhide`, `edit` |
+| `action` | string | **yes** | One of: `log`, `delete`, `hide`, `unhide`, `edit`, `token_purge` |
 | `document` | string | no | Single document permalink ID |
 | `documents` | array | no | Array of document permalink IDs (batch operations) |
 | `size` | integer | no | Number of audit log entries (for `action=log`, default: 50) |
 | `page` | integer | no | Page offset for audit log |
 | `filter` | string | no | Filter audit log by action type |
+| `cid` | string | no | (`token_purge`) Account id whose tokens to purge |
+| `email` | string | no | (`token_purge`) Email whose tokens to purge (resolves to every account with that address) |
 
 **Actions:**
 
@@ -347,6 +481,13 @@ POST /api/mgmt.json
 - `hide` — Hide emails from public view (recoverable)
 - `unhide` — Restore previously hidden emails
 - `edit` — Edit email metadata (list-id, etc.)
+- `token_purge` — Revoke **all** API tokens belonging to a user. Identify the
+  user by `cid` or `email` (at least one is required). Intended for when a
+  user's upstream credentials are reset or compromised and every long-term
+  token they hold must be cut off at once. Each purge is recorded in the audit
+  log as a `token_purge` entry. (Note: a normal login that changes a user's
+  OAuth identity already purges their tokens automatically — see
+  [`tokens.revoke_on_identity_change`](configuration.md#tokens).)
 
 #### Response
 
@@ -354,6 +495,12 @@ Varies by action. For `log`:
 
 ```json
 {"entries": [ /* audit log entries */ ]}
+```
+
+For `token_purge`:
+
+```json
+{"okay": true, "accounts": ["3f9a…c1"], "deleted": 4, "message": "Purged 4 token(s)."}
 ```
 
 For mutations: returns an `ActionResponse` with `okay` and `message`.

--- a/docs/API.md
+++ b/docs/API.md
@@ -83,6 +83,156 @@ curl -H "Authorization: Bearer pmt_XXXXXXXX..." \
      "https://lists.example.org/api/mbox.json?list=dev@example.org&date=2024-01"
 ```
 
+### How token authentication works
+
+The diagrams below show every component involved: the authoritative **OAuth**
+provider, `main.py` (request entry + scope gate), `session.py`, `token.py`, the
+three OpenSearch indices, the **optional** in-memory token cache, and the
+`background.py` housekeeping sweep.
+
+#### Components
+
+```mermaid
+flowchart TB
+    UI["Web UI (browser)"]
+    Script["Script / automation"]
+    OAuth["Authoritative OAuth provider"]
+
+    subgraph Server["Foal server"]
+        Main["main.py<br/>request entry + scope gate"]
+        Sess["session.py<br/>get_session"]
+        Cache["optional token cache<br/>(tokens.cache_ttl)"]
+        Tok["token.py<br/>create / lookup / revoke / purge"]
+        BG["background.py<br/>periodic sweep"]
+    end
+
+    subgraph ES["OpenSearch indices"]
+        AcctIdx["ponymail-account"]
+        SessIdx["ponymail-session"]
+        TokIdx["ponymail-token"]
+    end
+
+    UI -->|OAuth login| OAuth
+    OAuth -->|identity + group membership| Sess
+    Sess -->|store cookie session| SessIdx
+    Sess -->|store credentials| AcctIdx
+
+    UI -->|cookie| Main
+    Script -->|Bearer pmt token| Main
+    Main --> Sess
+    Sess <-->|hit / miss| Cache
+    Sess -->|validate token| Tok
+    Tok --> TokIdx
+    Tok -->|current permissions| AcctIdx
+
+    BG -->|purge expired| TokIdx
+    OAuth -.->|identity or permission change| Tok
+```
+
+#### Creating a token
+
+Tokens can only be minted from an interactive (cookie) session established via
+OAuth — a token can never create another token. Only a SHA-256 digest of the
+secret is stored, so the raw token is shown to the user exactly once.
+
+```mermaid
+sequenceDiagram
+    actor User as User (browser)
+    participant OA as OAuth provider
+    participant API as main.py
+    participant TP as token.py
+    participant AS as ES ponymail-account
+    participant TS as ES ponymail-token
+
+    User->>OA: interactive OAuth login
+    OA-->>API: identity + group membership
+    API->>AS: upsert account credentials (cid)
+    Note over API,User: user now holds a cookie session
+
+    User->>API: POST /api/token.json (create, scopes, expires)
+    Note over API: rejected unless caller has a cookie session
+    API->>TP: create_token(cid, scopes, expires)
+    TP->>TP: raw = "pmt_" + 256-bit random secret
+    TP->>TS: store id=SHA-256(raw), cid, scopes, expires
+    TP-->>User: raw token (shown once; only its hash is kept)
+```
+
+#### Authenticating a request
+
+A bearer token is validated on every request (no cookie-lifetime limit). With
+the optional cache enabled (`tokens.cache_ttl > 0`) a recently-seen token skips
+the two database reads, at the cost of delaying revocation/expiry by up to
+`cache_ttl` seconds. The effective access is the intersection of the token's
+scopes and the owner's **current** account permissions, so a token can only ever
+restrict access, never escalate it.
+
+```mermaid
+sequenceDiagram
+    participant C as Client (script)
+    participant API as main.py
+    participant S as session.py
+    participant Ca as token cache (optional)
+    participant TS as ES ponymail-token
+    participant AS as ES ponymail-account
+
+    C->>API: GET /api/mbox.json + Bearer pmt_...
+    API->>S: get_session(request)
+
+    opt tokens.cache_ttl > 0
+        S->>Ca: lookup SHA-256(token)
+        Ca-->>S: fresh hit -> reuse session, skip DB
+    end
+
+    S->>TS: lookup_token(SHA-256(token))
+    alt unknown or expired
+        TS-->>S: not found (expired deleted on lookup)
+        S-->>API: token_invalid = true
+        API-->>C: 403 Invalid or expired API token
+    else valid
+        TS-->>S: cid, scopes, expires
+        S->>AS: fetch account(cid) current permissions
+        S->>Ca: store entry for cache_ttl (if enabled)
+        S-->>API: token session (scopes + live permissions)
+        alt endpoint scope not granted
+            API-->>C: 403 token lacks required scope
+        else scope granted
+            Note over API: effective access = permissions AND scopes
+            API-->>C: 200 response
+        end
+    end
+```
+
+#### Revocation and expiry
+
+Five mechanisms make sure a token cannot outlive the access it was minted for.
+All of them delete the row from `ponymail-token`, after which the next request
+carrying that token gets a `403`.
+
+```mermaid
+flowchart LR
+    U["User<br/>token.json revoke"]
+    A["Admin<br/>mgmt token_purge (cid or email)"]
+    O["OAuth re-login with changed<br/>identity/permissions<br/>(revoke_on_identity_change)"]
+    E["Token passes its expires time"]
+    BG["background.py periodic sweep"]
+
+    TS[("ponymail-token")]
+    Ca[("optional token cache")]
+    Done["Next request with the token -> 403"]
+
+    U -->|revoke_token cid,tid| TS
+    A -->|purge_tokens_for_cid| TS
+    O -->|purge_tokens_for_cid| TS
+    E -->|lazy delete on next lookup| TS
+    BG -->|purge_expired_tokens| TS
+    BG -->|drop stale entries| Ca
+
+    TS --> Done
+```
+
+See [`plugins/token.py`](../server/plugins/token.py) and
+[`plugins/session.py`](../server/plugins/session.py) for the implementation.
+
 ---
 
 ## Endpoints

--- a/docs/admin_guide.md
+++ b/docs/admin_guide.md
@@ -99,6 +99,37 @@ curl -X POST https://your-instance/api/mgmt.json \
   -d '{"action": "log", "filter": "delete"}'
 ```
 
+Alongside the admin email actions (`edit`, `delete`, `hide`, ...), the audit
+log also records API token lifecycle events — `token_create`, `token_revoke`,
+and `token_purge` — including the acting user and the token's scopes.
+
+### Revoking a user's API tokens
+
+When a user's upstream credentials are reset or compromised, you can cut off
+every long-term API token they hold in one call, identifying them by account id
+(`cid`) or email address:
+
+```bash
+curl -X POST https://your-instance/api/mgmt.json \
+  -H "Content-Type: application/json" \
+  -H "Cookie: ponymail=your-session-cookie" \
+  -d '{"action": "token_purge", "email": "user@example.org"}'
+```
+
+This deletes all of that user's tokens (an `email` may resolve to more than one
+account if they have logged in via several OAuth providers) and writes a
+`token_purge` audit entry per account.
+
+In most cases you do not need to do this by hand: with
+`tokens.revoke_on_identity_change` enabled (the default), a user's tokens are
+purged automatically the next time they log in if their OAuth identity or
+permissions have changed. The manual action above is for when you cannot wait
+for that next login — e.g. a credential is known to be compromised right now.
+Remember that a token can never do more than the account currently can: if you
+instead remove the user's access at the OAuth/authoritative-domain or
+`oauth.admins` level, their tokens lose that access on their very next request
+regardless.
+
 ---
 
 ## Command-Line Tools

--- a/docs/api_client_guide.md
+++ b/docs/api_client_guide.md
@@ -38,7 +38,24 @@ All examples below show both modes.
 ## Authentication
 
 Public lists require no authentication. For private lists or write
-operations, include a session cookie:
+operations, authenticate in one of two ways.
+
+**Long-term API token (recommended for scripts).** Log in to the web UI,
+open the user menu → **API Tokens**, and create a token. Send it as a
+bearer token on each request:
+
+```
+Authorization: Bearer pmt_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+Tokens are not tied to a browser and do not expire on the short session
+schedule, which makes them ideal for automation. A token grants access up to
+that of the account that created it, limited by the scopes you select
+(`read` / `write` / `admin`; defaults to read-only). The raw token is shown only once, at
+creation time — store it securely. Tokens can be listed and revoked from the
+same **API Tokens** panel, or via [`token.json`](API.md#tokenjson).
+
+**Session cookie (interactive).** Alternatively, include the session cookie:
 
 ```
 Cookie: ponymail=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
@@ -191,5 +208,6 @@ There is no rate limiting on the API. However, be respectful:
 ## Related
 
 - [API.md](API.md) — Full endpoint reference with response schemas
+- [generating_api_clients.md](generating_api_clients.md) — Auto-generate a typed client from the OpenAPI spec instead of hand-writing one
 - [search.md](search.md) — Search query syntax
-- GitHub issue [#312](https://github.com/apache/incubator-ponymail-foal/issues/312) — API token support (not yet implemented)
+- GitHub issue [#312](https://github.com/apache/incubator-ponymail-foal/issues/312) — API token support (implemented; see [Authentication](#authentication))

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,6 +91,7 @@ default `ponymail`):
 | `ponymail-mbox` | Parsed email metadata (from, subject, date, body, list-id, threading info) |
 | `ponymail-source` | Raw RFC 2822 email source (the original message as received) |
 | `ponymail-account` | User session/preference data |
+| `ponymail-token` | Long-term API tokens (SHA-256 hash, owner, scopes, expiry) |
 | `ponymail-auditlog` | Admin action audit trail |
 
 ---
@@ -138,7 +139,8 @@ Optional threading metadata (enabled via `archiver.threadinfo` config):
    - Strips suffix (`.lua` → form parsing, `.json` → JSON parsing)
    - Looks up handler name in `self.handlers` dict
    - Acquires a database connection from the async pool
-   - Creates a session object (validates cookie if present)
+   - Creates a session object (validates the cookie or, for programmatic
+     clients, an `Authorization: Bearer` API token if present)
 4. **Endpoint** `process(server, session, indata)` executes:
    - Builds OpenSearch query via `plugins.defuzzer` (normalizes dates/filters)
    - Checks access via `plugins.aaa` (private list filtering)
@@ -158,10 +160,11 @@ user-installable extensions.
 | `configuration.py` | YAML config parsing (all config keys defined here) |
 | `database.py` | Async OpenSearch client, connection pool, index names |
 | `messages.py` | Email retrieval, threading logic, access filtering, trimming |
-| `session.py` | Cookie management, OAuth credential tracking |
+| `session.py` | Cookie management, API token authentication, OAuth credential tracking |
 | `aaa.py` | Access control (public vs private list checks) |
 | `defuzzer.py` | Date/query parameter normalization and validation |
-| `background.py` | Periodic tasks (refresh list counts, activity stats) |
+| `background.py` | Periodic tasks (refresh list counts, activity stats, purge expired API tokens) |
+| `token.py` | API token generation, SHA-256 hashing, per-action scopes, expiry |
 | `formdata.py` | Request body parsing (form-encoded vs JSON) |
 | `offloader.py` | Thread pool executor for CPU-bound JSON serialization |
 | `auditlog.py` | Admin action audit trail |

--- a/docs/asfquart_migration.md
+++ b/docs/asfquart_migration.md
@@ -1,0 +1,130 @@
+<!---
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+# asfquart / ATR Alignment and Future Migration
+
+This note explains how Foal's long-term [API tokens](API.md#authentication) relate
+to the token/authentication model used by
+[asfquart](https://github.com/apache/infrastructure-asfquart) — the framework
+several ASF Tooling and Infrastructure web apps are built on — and by
+[ATR (`apache/tooling-trusted-releases`)](https://github.com/apache/tooling-trusted-releases),
+which builds a full token subsystem on top of asfquart.
+
+It has two purposes:
+
+1. **Mirror the semantics** so that Foal's tokens are conceptually compatible with
+   asfquart/ATR today, without taking a Quart dependency.
+2. **Record the migration steps** should Foal ever move onto Quart/asfquart.
+
+A small, tested reference implementation of the mapping lives in
+[`server/plugins/asfquart_compat.py`](../server/plugins/asfquart_compat.py). It is
+**not** wired into the request path — it exists to keep the translation honest and
+in one reviewed place.
+
+## What asfquart actually provides
+
+asfquart is *not* a token manager. It provides the authentication **seam** and the
+authorization **vocabulary**:
+
+- A **bearer hook**: `session.py` turns an `Authorization: Bearer <token>` header
+  into a session by calling a pluggable `app.token_handler(token)` callback that
+  the application supplies. asfquart itself does not generate, store, expire, or
+  revoke tokens.
+- A **session shape** (`asfquart.session.ClientSession`): `uid`, `email`,
+  `fullname`, `isMember` / `isChair` / `isRoot`, `pmcs`, `projects`, `mfa`,
+  `roleaccount`, and a free-form `metadata` dict. By convention (see asfquart's
+  `personal_access_tokens.py` example, which ATR follows) a token's scope lives at
+  `metadata["scope"]`.
+- **Requirement decorators**: `@asfquart.auth.require(Requirements.member)` etc.,
+  where each requirement is `fn(client_session) -> (passes, message)`, combinable
+  with `all_of` / `any_of`.
+
+Everything else — generation, hashed storage, expiry, per-user caps, scope
+intersection, admin/auto revocation, audit — is application code. In asfquart-land
+that machinery currently lives in **ATR**, not in asfquart. Foal implements its own
+equivalent (see [`plugins/token.py`](../server/plugins/token.py)); the two are
+parallel implementations of the same idea on different web stacks (ATR on Quart,
+Foal on `aiohttp`).
+
+### Design difference worth knowing
+
+ATR issues a long-lived Personal Access Token that is exchanged for a short-lived
+(30-minute, HS256) JWT which authenticates each API call. Foal uses the opaque
+token **directly** on every request and re-intersects its scope with the owner's
+**current** account permissions server-side each time. Both are valid; they trade
+off differently on revocation latency vs. per-request cost. Foal's model needs no
+token exchange endpoint and revokes effectively immediately; ATR's JWT avoids a
+token lookup per call at the cost of a short revocation delay.
+
+## Semantic mapping
+
+| Foal (`SessionObject` / `plugins.token`)      | asfquart / ATR                                 | Notes |
+|-----------------------------------------------|------------------------------------------------|-------|
+| `credentials.uid`                             | `uid`                                          | |
+| `credentials.email`                           | `email`                                        | |
+| `credentials.name`                            | `fullname`                                     | |
+| `credentials.admin`                           | `isRoot`                                        | Closest analogue to infra-root membership. |
+| `session.token` (Bearer auth)                 | `roleaccount`                                   | asfquart's PAT example models tokens as role accounts. |
+| `session.token_scopes`                        | `metadata["scope"]`                            | Same key asfquart reads. |
+| `token.required_scope(handler)`               | a `Requirements`-style predicate               | See `scope_requirement()`. |
+| `token.token_allows(session, handler)`        | `@asfquart.auth.require(...)`                   | Same allow/deny outcome. |
+| *(not tracked)*                               | `isMember`, `isChair`, `pmcs`, `projects`, `mfa` | Foal does not model ASF org roles; a Quart deployment would fill these from the OAuth payload. |
+
+`scope_requirement(scope)` returns a predicate shaped exactly like an
+`asfquart.auth.Requirements` member, so the per-endpoint rule enforced today in
+`main.py` via `token.token_allows(...)` could instead be attached declaratively:
+
+```python
+@asfquart.auth.require(scope_requirement(token.required_scope(handler)))
+async def handler(...):
+    ...
+```
+
+An interactive (cookie) session is rendered with all scopes, so it satisfies every
+requirement — matching today's rule that only token sessions are scope-restricted.
+
+The mapping is covered by [`test/test_asfquart_compat.py`](../test/test_asfquart_compat.py),
+which asserts that `scope_requirement` agrees with `token.token_allows` for every
+endpoint/scope pairing, so the two never drift.
+
+## Future migration steps (should Foal move to Quart/asfquart)
+
+Foal's server is a hand-rolled `aiohttp` application, so adopting asfquart is a
+reframing, not a drop-in. If that is ever undertaken, the token work done here is
+designed to make it incremental:
+
+1. **Add the dependency** and stand up an asfquart `APP` alongside (or in front of)
+   the existing server, sharing the OpenSearch backend.
+2. **Register a `token_handler`** that calls the existing
+   `plugins.token.lookup_token()` and returns `asfquart_compat.to_asfquart_session()`
+   for the resolved account. This reuses generation/storage/expiry/revocation
+   unchanged — only the *presentation* of the session changes.
+3. **Populate the org-role fields** (`isMember`, `isChair`, `pmcs`, `projects`,
+   `mfa`) from the OAuth payload Foal already receives, so asfquart's
+   `Requirements` gain real backing data instead of the empty defaults.
+4. **Replace the central scope check** in `main.py` with per-endpoint
+   `@asfquart.auth.require(scope_requirement(...))` decorators. Because the
+   predicate already mirrors `token_allows`, this is a mechanical move with no
+   behavioural change.
+5. **Consider aligning revocation** with any shared asfquart/ATR token layer if one
+   materialises upstream (ATR's admin purge / banning) — Foal's `purge_tokens_for_cid`
+   and OAuth-fingerprint auto-revocation are the natural integration points.
+6. **Optionally adopt the PAT→JWT exchange** if per-request token lookups become a
+   bottleneck; until then Foal's direct-token model keeps revocation immediate.
+
+Steps 2–4 can land independently and be reverted independently, so the migration
+need not be a single big-bang change.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -117,6 +117,58 @@ ui:
 
 ---
 
+## `tokens`
+
+Long-term API tokens let logged-in users authenticate to the API
+programmatically via an `Authorization: Bearer <token>` header, without the
+short session-cookie lifetime. See the [API documentation](API.md#authentication).
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `false` | Allow creating and using API tokens. When `false`, the `token.json` endpoint is disabled and bearer tokens are ignored |
+| `default_lifetime` | integer | `2592000` (30 days) | Default token lifetime in seconds when the user does not request one. `0` means the token never expires |
+| `max_lifetime` | integer | `0` (no limit) | Upper bound on token lifetime in seconds. Requests above this (and `0`/never when this is set) are clamped down to it. `0` disables the cap |
+| `max_tokens` | integer | `25` | Maximum number of live tokens a single user may hold at once |
+| `cache_ttl` | integer | `0` | Seconds to cache token authentication in memory. `0` disables caching (default), so revocation and expiry take effect immediately. A value above `0` avoids two OpenSearch reads per token request on hot paths, at the cost of delaying revocation/expiry by up to that many seconds |
+| `cache_max` | integer | `10000` | Maximum number of entries in the in-memory token authentication cache (only relevant when `cache_ttl` > 0). The cache is flushed when it exceeds this, bounding memory use |
+| `revoke_on_identity_change` | boolean | `true` | When a user logs in and their OAuth identity/permissions differ from what was last stored (e.g. after an upstream credential reset or a change in group membership), automatically revoke all of that user's API tokens, so a token minted under the old identity cannot be reused. Set to `false` to keep tokens across identity changes |
+
+Example:
+```yaml
+tokens:
+  enabled: true
+  default_lifetime: 2592000   # 30 days
+  max_lifetime: 31536000      # 1 year hard cap
+  max_tokens: 25
+  revoke_on_identity_change: true
+```
+
+> **Note:** Tokens are opt-in. Before setting `enabled: true`, make sure the
+> `<prefix>-token` OpenSearch index exists. Fresh installs create it
+> automatically via `tools/setup.py`. Existing installs must create it first,
+> e.g. from the `tools/` directory:
+> `python3 mappings.py --shards 1 --replicas 0 token`.
+>
+> Enabling API tokens is a deployment decision: because tokens outlive the
+> short cookie session, an operator may prefer to leave them off, or to cap
+> their lifetime with `max_lifetime`. On a shared/managed instance this should
+> be coordinated with whoever runs the service (for ASF instances, Infra).
+
+**Cutting off a user's tokens.** Two mechanisms revoke *all* of a user's tokens
+at once, on top of a user revoking individual tokens via `token.json`:
+
+- **Automatic**, on the next login after their OAuth identity changes, when
+  `revoke_on_identity_change` is `true` (the default).
+- **Manual**, by an administrator, via the
+  [`token_purge`](API.md#mgmtjson) action of `mgmt.json` — useful when a
+  credential is known to be compromised and you cannot wait for the user's next
+  login.
+
+Neither depends on `cache_ttl`: with the default `cache_ttl: 0` a purge takes
+effect immediately; a non-zero cache delays it by up to that many seconds.
+
+---
+
 ## `oauth`
 
 OAuth authentication configuration. Controls which OAuth providers are

--- a/docs/generating_api_clients.md
+++ b/docs/generating_api_clients.md
@@ -1,0 +1,217 @@
+<!---
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+# Generating API Client Libraries
+
+**You do not have to hand-write a client for the Foal API.** The server ships a
+machine-readable [OpenAPI 3.0](https://spec.openapis.org/oas/v3.0.0) description
+of its endpoints at [`server/openapi.yaml`](../server/openapi.yaml), and a wide
+range of off-the-shelf generators turn that single file into a ready-to-use,
+typed client library in almost any language.
+
+## Why generate instead of replicate
+
+Several tools benefit from long-term API tokens and from talking to the API in
+general — the [Pony Mail MCP](https://github.com/apache/comdev/tree/main/mcp/ponymail-mcp),
+internal scripts, dashboards, bots, and so on. Re-implementing the request
+plumbing, auth handling, and response types by hand in each of them multiplies
+the maintenance burden: a bug fixed in one copy has to be chased down in all the
+others.
+
+The OpenAPI spec avoids that. It is the **single shared contract**: the server
+maintains it alongside the code, and every consumer *derives* its client from
+it rather than duplicating it. When an endpoint changes, you regenerate — you do
+not hand-patch N separate clients. The shared, maintained artifact is the spec,
+not copy-pasted client code.
+
+> The spec is the source of truth. If you find the spec is missing an endpoint
+> or a field you need, fix `server/openapi.yaml` (and regenerate) rather than
+> working around it in a client — that keeps the benefit for every other
+> consumer.
+
+## Prerequisites
+
+- The spec file: [`server/openapi.yaml`](../server/openapi.yaml). You can point a
+  generator at a local checkout, or at a copy hosted by your instance.
+- A generator. The two most common:
+  - **[OpenAPI Generator](https://openapi-generator.tech/)** — the most widely
+    used, ~50 target languages/frameworks. Examples below use this.
+  - **[swagger-codegen](https://github.com/swagger-api/swagger-codegen)** — the
+    older sibling; comparable usage.
+
+Install OpenAPI Generator whichever way suits you:
+
+```bash
+# Homebrew (macOS)
+brew install openapi-generator
+
+# npm (cross-platform)
+npm install -g @openapitools/openapi-generator-cli
+
+# Or with no install at all, via the official Docker image (used below)
+docker pull openapitools/openapi-generator-cli
+```
+
+It is worth validating the spec first — this also confirms your toolchain works:
+
+```bash
+openapi-generator validate -i server/openapi.yaml
+```
+
+## Authentication in generated clients
+
+The spec declares two security schemes, so generated clients expose both:
+
+| Scheme | How the client sends it | Use |
+|--------|-------------------------|-----|
+| `bearerAuth` | `Authorization: Bearer <token>` | **Long-term API tokens** (`pmt_…`) — recommended for scripts/automation |
+| `cookieAuth` | `Cookie: ponymail=<session>` | Interactive browser sessions |
+
+For programmatic use you almost always want `bearerAuth`. Create a token from
+the web UI (user menu → **API Tokens**) or via
+[`token.json`](API.md#tokenjson), then hand the `pmt_…` secret to the generated
+client as shown per language below. (Token *management* — create/list/revoke —
+is deliberately cookie-only and cannot be driven with a bearer token; see
+[API.md](API.md#tokenjson).)
+
+## Examples
+
+Each example generates a client into `./out` from a local checkout. Swap the
+Docker invocation for a direct `openapi-generator-cli` call if you installed it
+natively (the arguments are identical); with Docker, mount the working directory
+so the tool can read the spec and write the output:
+
+```bash
+DOCKER="docker run --rm -v ${PWD}:/local -w /local openapitools/openapi-generator-cli"
+```
+
+### Python
+
+```bash
+$DOCKER generate \
+  -i server/openapi.yaml \
+  -g python \
+  -o out/python-client \
+  --additional-properties=packageName=ponymail_client
+```
+
+```python
+import ponymail_client
+from ponymail_client.rest import ApiException
+
+config = ponymail_client.Configuration(
+    host="https://lists.apache.org/api",
+    access_token="pmt_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",  # bearerAuth
+)
+
+with ponymail_client.ApiClient(config) as client:
+    api = ponymail_client.DefaultApi(client)
+    try:
+        result = api.api_stats_json_post(...)  # method names follow the spec's operationIds
+        print(result)
+    except ApiException as e:
+        print("API error:", e)
+```
+
+### TypeScript / JavaScript
+
+```bash
+$DOCKER generate \
+  -i server/openapi.yaml \
+  -g typescript-fetch \
+  -o out/ts-client
+```
+
+```ts
+import { Configuration, DefaultApi } from "./out/ts-client";
+
+const api = new DefaultApi(
+  new Configuration({
+    basePath: "https://lists.apache.org/api",
+    accessToken: "pmt_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", // bearerAuth
+  }),
+);
+
+const stats = await api.apiStatsJsonPost({ /* … */ });
+console.log(stats);
+```
+
+### Go
+
+```bash
+$DOCKER generate \
+  -i server/openapi.yaml \
+  -g go \
+  -o out/go-client \
+  --additional-properties=packageName=ponymail
+```
+
+```go
+ctx := context.WithValue(context.Background(), ponymail.ContextAccessToken,
+    "pmt_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX") // bearerAuth
+
+cfg := ponymail.NewConfiguration()
+cfg.Servers = ponymail.ServerConfigurations{{URL: "https://lists.apache.org/api"}}
+client := ponymail.NewAPIClient(cfg)
+
+stats, _, err := client.DefaultApi.ApiStatsJsonPost(ctx).Execute()
+```
+
+### Java
+
+```bash
+$DOCKER generate \
+  -i server/openapi.yaml \
+  -g java \
+  -o out/java-client \
+  --additional-properties=library=native,invokerPackage=org.apache.ponymail.client
+```
+
+```java
+ApiClient client = Configuration.getDefaultApiClient();
+client.setBasePath("https://lists.apache.org/api");
+client.setBearerToken("pmt_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"); // bearerAuth
+
+DefaultApi api = new DefaultApi(client);
+```
+
+Other targets (`csharp`, `rust`, `php`, `ruby`, `kotlin`, …) work the same way:
+change `-g` and the auth-configuration idiom is analogous.
+
+## Keeping generated code healthy
+
+- **Treat generated clients as build artifacts.** Prefer regenerating them in
+  CI from a pinned spec version over committing large generated trees — the same
+  reasoning the server uses for its own built files. If you do commit a client,
+  commit the generator command/version next to it so it is reproducible.
+- **Pin the generator version** (e.g. a specific `openapi-generator-cli` image
+  tag) so output is stable across machines and over time.
+- **Regenerate when the spec changes.** Watch `server/openapi.yaml`; a diff
+  there is your signal to regenerate and re-test the client.
+- **Coverage caveats.** The spec covers the JSON API endpoints documented in
+  [API.md](API.md). A few operations — notably the admin `mgmt.json` actions —
+  are intentionally not in the spec; call those directly if you need them.
+  Public read endpoints require no credentials, so a generated client can be
+  used anonymously for public lists and only needs a token for private lists or
+  writes.
+
+## Related
+
+- [API.md](API.md) — Full endpoint reference, authentication, and scopes
+- [API Client Guide](api_client_guide.md) — Hand-rolled `curl`/HTTP examples
+- [`server/openapi.yaml`](../server/openapi.yaml) — The spec these clients are generated from
+- [OpenAPI Generator documentation](https://openapi-generator.tech/docs/generators/) — Full list of target languages and options

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,7 @@
 
 - [API Reference](API.md) — HTTP endpoint specifications
 - [API Client Guide](api_client_guide.md) — Curl examples and integration patterns
+- [Generating API Client Libraries](generating_api_clients.md) — Auto-generate typed clients from the OpenAPI spec
 - [Plugin & Endpoint Development](plugins.md) — How to extend Foal
 - [Style Guide](STYLEGUIDE.md) — Code conventions (Python + JavaScript)
 - [Versioning & Releases](releases.md) — How versions are tracked

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,7 @@
 - [API Reference](API.md) — HTTP endpoint specifications
 - [API Client Guide](api_client_guide.md) — Curl examples and integration patterns
 - [Generating API Client Libraries](generating_api_clients.md) — Auto-generate typed clients from the OpenAPI spec
+- [asfquart / ATR Alignment](asfquart_migration.md) — How API tokens map to asfquart/ATR, and future Quart migration steps
 - [Plugin & Endpoint Development](plugins.md) — How to extend Foal
 - [Style Guide](STYLEGUIDE.md) — Code conventions (Python + JavaScript)
 - [Versioning & Releases](releases.md) — How versions are tracked

--- a/server/endpoints/mgmt.py
+++ b/server/endpoints/mgmt.py
@@ -21,6 +21,8 @@ import plugins.server
 import plugins.session
 import plugins.messages
 import plugins.auditlog
+import plugins.database
+import plugins.token
 import re
 import typing
 import aiohttp.web
@@ -252,6 +254,48 @@ async def process(
                 return user_error("No changes made!")
 
         return aiohttp.web.Response(headers={}, status=404, text="Email not found!")
+
+    # Purge *all* API tokens belonging to a user. Intended for the case where a
+    # user's upstream credentials are reset/compromised and every long-term
+    # token they hold must be cut off at once. The target is identified either
+    # by account id (``cid``) or by ``email`` (which may resolve to more than one
+    # account if the user has logged in via several OAuth providers).
+    elif action == "token_purge":
+        target_cid = str(indata.get("cid", "")).strip()
+        target_email = str(indata.get("email", "")).strip().lower()
+        if not target_cid and not target_email:
+            return user_error("token_purge requires a 'cid' or 'email' to identify the user.")
+
+        cids: typing.List[str] = []
+        if target_cid:
+            cids.append(target_cid)
+        else:
+            # Resolve the email to every account id that carries it. credentials.email
+            # is a keyword field, so an exact term match is appropriate here.
+            res = await session.database.search(
+                index=session.database.dbs.db_account,
+                size=100,
+                body={"query": {"term": {"credentials.email": target_email}}},
+            )
+            cids = [hit["_source"]["cid"] for hit in res["hits"]["hits"] if hit["_source"].get("cid")]
+            if not cids:
+                return aiohttp.web.Response(headers={}, status=404, text="No account found for that email.")
+
+        total = 0
+        for target in cids:
+            total += await plugins.token.purge_tokens_for_cid(session.database, target)
+            try:
+                await plugins.auditlog.add_entry(
+                    session,
+                    action="token_purge",
+                    target=target,
+                    lid="",
+                    log="Purged all API tokens for account %s%s"
+                    % (target, (" (%s)" % target_email) if target_email else ""),
+                )
+            except plugins.database.DBError:
+                pass
+        return {"okay": True, "accounts": cids, "deleted": total, "message": "Purged %d token(s)." % total}
 
     return aiohttp.web.Response(headers={}, status=404, text="Unknown mgmt command requested")
 

--- a/server/endpoints/oauth.py
+++ b/server/endpoints/oauth.py
@@ -22,6 +22,8 @@ import plugins.session
 import plugins.oauthGeneric
 import plugins.oauthGoogle
 import plugins.oauthGithub
+import plugins.database
+import plugins.token
 import typing
 import aiohttp.web
 import hashlib
@@ -68,6 +70,26 @@ async def process(
             authoritative = oauth_provider in server.config.oauth.authoritative_domains
             admin = authoritative and rv.get("email") in server.config.oauth.admins
             debug(server, f"oauth/aa: {authoritative} {admin}")
+
+            # Capture the identity we had on file *before* set_session overwrites
+            # the account document, so we can tell whether this login represents a
+            # changed upstream setup (see the token purge below).
+            prior_oauth_data: typing.Optional[dict] = None
+            had_prior_account = False
+            if (
+                server.config.tokens.enabled
+                and server.config.tokens.revoke_on_identity_change
+                and session.database
+            ):
+                try:
+                    prior_doc = await session.database.get(
+                        session.database.dbs.db_account, id=cid
+                    )
+                    had_prior_account = True
+                    prior_oauth_data = prior_doc["_source"].get("internal", {}).get("oauth_data", {})
+                except plugins.database.DBError:
+                    pass
+
             cookie = await plugins.session.set_session(
                 server,
                 cid,
@@ -81,6 +103,25 @@ async def process(
                 oauth_data=rv,
                 admin=admin,
             )
+
+            # If the user's upstream identity/permissions changed since we last
+            # saw them, drop every long-term token they hold: a token minted
+            # under the old setup must not survive a credential reset or a change
+            # in group membership. Only acts on an existing account (a first-ever
+            # login has nothing to revoke) and is best-effort — a purge failure
+            # must never block the login itself.
+            if (
+                had_prior_account
+                and session.database
+                and plugins.token.oauth_setup_changed(prior_oauth_data, rv)
+            ):
+                try:
+                    purged = await plugins.token.purge_tokens_for_cid(session.database, cid)
+                    if purged:
+                        debug(server, f"oauth: purged {purged} token(s) for {cid} after identity change")
+                except plugins.database.DBError:
+                    pass
+
             # This could be improved upon, instead of a raw response return value
             return aiohttp.web.Response(
                 headers={"set-cookie": cookie, "content-type": "application/json"}, status=200, text='{"okay": true}',

--- a/server/endpoints/preferences.py
+++ b/server/endpoints/preferences.py
@@ -46,6 +46,7 @@ async def process(
 
     prefs: dict = {"login": {}}
     prefs['versions'] = versions
+    prefs['tokens'] = {"enabled": server.config.tokens.enabled}
     if indata.get('oauth'):
         # filter subkeys starting with .
         # the providers is a dict of dicts; we want to filter out keys in the inner dict that start with '.'
@@ -83,8 +84,9 @@ async def process(
             if server.config.ui.fully_delete:  # Needed by the UI
                 prefs["login"]["credentials"]["fully_delete"] = True
 
-    # Logging out??
-    if indata.get("logout"):
+    # Logging out?? (only meaningful for cookie sessions - an API token has no
+    # server-side login session to remove; it is revoked via /api/token instead)
+    if indata.get("logout") and not session.token:
         # Remove session from ElasticSearch
         await plugins.session.remove_session(session)
 

--- a/server/endpoints/token.py
+++ b/server/endpoints/token.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Long-term API token management endpoint for Pony Mail codename Foal.
+
+Actions (via ?action= or JSON body):
+  * list   (default) - list the calling user's tokens (metadata only)
+  * create           - mint a new token; the raw secret is returned ONCE
+  * revoke           - delete a token by id
+
+Tokens themselves are used by sending 'Authorization: Bearer <token>' on any
+API request; see plugins/token.py and plugins/session.py.
+"""
+
+import time
+import typing
+
+import aiohttp.web
+
+import plugins.auditlog
+import plugins.database
+import plugins.server
+import plugins.session
+import plugins.token
+
+
+def _json(payload: dict, status: int = 200) -> aiohttp.web.Response:
+    import json
+
+    return aiohttp.web.Response(
+        headers={"content-type": "application/json"},
+        status=status,
+        text=json.dumps(payload),
+    )
+
+
+async def process(
+    server: plugins.server.BaseServer,
+    request: aiohttp.web.BaseRequest,
+    session: plugins.session.SessionObject,
+    indata: dict,
+) -> typing.Union[dict, aiohttp.web.Response]:
+
+    if not server.config.tokens.enabled:
+        return _json({"okay": False, "message": "API tokens are disabled on this server."}, 403)
+
+    # Must be logged in (interactively) to manage tokens.
+    if not session.credentials or not session.cid:
+        return _json({"okay": False, "message": "You must be logged in to manage API tokens."}, 403)
+
+    # Tokens may not be managed using token authentication - this prevents a
+    # leaked token from silently minting more tokens or covering its tracks.
+    if session.token:
+        return _json(
+            {"okay": False, "message": "API tokens must be managed via an interactive login, not a token."},
+            403,
+        )
+
+    assert session.database, "Session not connected to database!"
+    action = indata.get("action", "list")
+
+    if action in ("create", "revoke"):
+        if request.method != "POST" or request.content_type != "application/json" or "action" in request.query:
+            return _json(
+                {"okay": False, "message": "Token create/revoke actions require a JSON POST body."},
+                405,
+            )
+
+    if action == "list":
+        tokens = await plugins.token.list_tokens(session.database, session.cid)
+        return {"okay": True, "tokens": tokens}
+
+    if action == "create":
+        existing = await plugins.token.count_tokens(session.database, session.cid)
+        if existing >= server.config.tokens.max_tokens:
+            return _json(
+                {
+                    "okay": False,
+                    "message": "You already have the maximum of %d tokens. Revoke one first."
+                    % server.config.tokens.max_tokens,
+                },
+                400,
+            )
+
+        description = str(indata.get("description", "")).strip() or "API token"
+
+        # Determine lifetime (seconds). Fall back to the server default, and
+        # clamp to the configured maximum if one is set.
+        default_age = server.config.tokens.default_age
+        max_age = server.config.tokens.max_age
+        requested = indata.get("lifetime")
+        if requested is None or requested == "":
+            age = default_age
+        else:
+            try:
+                age = int(str(requested))
+            except (ValueError, TypeError):
+                age = default_age
+        if age < 0:
+            age = default_age
+        if max_age > 0 and (age == 0 or age > max_age):
+            age = max_age
+        expires = int(time.time()) + age if age > 0 else 0
+
+        # Scopes restrict what the token may do (defaults to read-only).
+        scopes = plugins.token.normalize_scopes(indata.get("scopes"))
+
+        result = await plugins.token.create_token(session.database, session.cid, description, expires, scopes)
+        # Best-effort audit trail; never block returning the one-time secret.
+        try:
+            await plugins.auditlog.add_entry(
+                session,
+                "token_create",
+                result["id"],
+                "",
+                "Created API token '%s' (scopes: %s)" % (description, ", ".join(scopes)),
+                refresh=False,
+            )
+        except plugins.database.DBError:
+            pass
+        return {"okay": True, **result}
+
+    if action == "revoke":
+        tid = indata.get("id")
+        if not tid:
+            return _json({"okay": False, "message": "No token id supplied."}, 400)
+        ok = await plugins.token.revoke_token(session.database, session.cid, str(tid))
+        if ok:
+            try:
+                await plugins.auditlog.add_entry(
+                    session, "token_revoke", str(tid), "", "Revoked API token %s" % tid, refresh=False
+                )
+            except plugins.database.DBError:
+                pass
+            return {"okay": True, "message": "Token revoked."}
+        return _json({"okay": False, "message": "Token not found."}, 404)
+
+    return _json({"okay": False, "message": "Unknown action '%s'." % action}, 400)
+
+
+def register(_server: plugins.server.BaseServer):
+    return plugins.server.StreamingEndpoint(process)

--- a/server/main.py
+++ b/server/main.py
@@ -37,6 +37,7 @@ import plugins.formdata
 import plugins.offloader
 import plugins.server
 import plugins.session
+import plugins.token
 
 from server_version import PONYMAIL_SERVER_VERSION
 PONYMAIL_FOAL_VERSION = "0.1.0"
@@ -165,6 +166,31 @@ class Server(plugins.server.BaseServer):
         # Find a handler, or 404
         if handler in self.handlers:
             session = await plugins.session.get_session(self, request)
+            # An expired or otherwise invalid bearer token is rejected explicitly
+            # (403) rather than silently downgraded to anonymous, so the client
+            # knows to refresh its credentials.
+            if session.token_invalid:
+                if session.database:
+                    self.dbpool.put_nowait(session.database)
+                    self.dbpool.task_done()
+                    session.database = None
+                return aiohttp.web.Response(
+                    headers={**headers, "content-type": "application/json"},
+                    status=403,
+                    text='{"okay": false, "message": "Invalid or expired API token."}',
+                )
+            # Enforce API-token scopes: a scoped token may only reach the
+            # endpoints its scopes permit. Cookie sessions are unaffected.
+            if not plugins.token.token_allows(session, handler):
+                if session.database:
+                    self.dbpool.put_nowait(session.database)
+                    self.dbpool.task_done()
+                    session.database = None
+                return aiohttp.web.Response(
+                    headers={**headers, "content-type": "application/json"},
+                    status=403,
+                    text='{"okay": false, "message": "This API token lacks the required scope for this endpoint."}',
+                )
             try:
                 # Wait for endpoint response. This is typically JSON in case of success,
                 # but could be an exception (that needs a traceback) OR

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -400,6 +400,15 @@ components:
       in: cookie
       name: ponymail
       type: apiKey
+    bearerAuth:
+      type: http
+      scheme: bearer
+      description: >-
+        Long-term API token sent as an `Authorization: Bearer <token>` header.
+        A token's access is the intersection of its scopes with the owner's
+        current permissions. See API.md#authentication. Token management
+        (`/api/token.json`) itself requires the interactive cookie session and
+        cannot be performed with a bearer token.
 paths:
   /api/compose.json:
     post:
@@ -426,6 +435,7 @@ paths:
       summary: Compose and dispatch an email to a list
       security:
       - cookieAuth: []
+      - bearerAuth: []
   /api/email.json:
     post:
       requestBody:
@@ -455,6 +465,7 @@ paths:
           description: unexpected error
       security:
       - cookieAuth: []
+      - bearerAuth: []
       summary: Fetches a single email and returns it as a JSON object
   /api/mbox.json:
     post:
@@ -479,6 +490,7 @@ paths:
           description: unexpected error
       security:
       - cookieAuth: []
+      - bearerAuth: []
       summary: Returns a list or a search result in mbox file format
   # /api/mgmt.json:
   #   TBA
@@ -565,6 +577,7 @@ paths:
           description: unexpected error
       security:
       - cookieAuth: []
+      - bearerAuth: []
       summary: Fetches the raw mbox source of an email
   /api/stats.json:
     post:
@@ -588,6 +601,7 @@ paths:
               example: "The search could not be completed"
       security:
       - cookieAuth: []
+      - bearerAuth: []
       summary: Searches the archives and returns the results that match
   /api/thread.json:
     post:
@@ -613,4 +627,71 @@ paths:
           description: unexpected error
       security:
       - cookieAuth: []
+      - bearerAuth: []
       summary: Fetches an email thread based on a parent email
+  /api/token.json:
+    post:
+      summary: Manage long-term API tokens (list, create, revoke)
+      description: >-
+        Requires an interactive (cookie) session; tokens cannot be managed using
+        token authentication. The raw token secret is returned only once, on create.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                action:
+                  type: string
+                  enum: [list, create, revoke]
+                  default: list
+                description:
+                  type: string
+                  description: Label for the token (create)
+                scopes:
+                  type: string
+                  description: Space/comma-separated scopes to grant (create); defaults to "read"
+                lifetime:
+                  type: integer
+                  description: Token lifetime in seconds, 0 = never expires (create)
+                id:
+                  type: string
+                  description: Id of the token to revoke (revoke)
+      responses:
+        '200':
+          description: Token list, or the created token including its one-time secret
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  okay:
+                    type: boolean
+                  token:
+                    type: string
+                    description: The raw token secret, present only on create
+                  tokens:
+                    type: array
+                    items:
+                      type: object
+        '400':
+          description: Unknown action, token limit reached, or missing id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Not logged in, tokens disabled, or attempted via token auth
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Token to revoke not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      security:
+      - cookieAuth: []

--- a/server/plugins/asfquart_compat.py
+++ b/server/plugins/asfquart_compat.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Forward-compatibility shim for asfquart / ATR token semantics.
+
+This module is **not** wired into the request path. It exists to demonstrate,
+in code, how PonyMail's API-token session maps onto the session/scope shape used
+by `asfquart <https://github.com/apache/infrastructure-asfquart>`_ and the token
+subsystem built on top of it in `ATR (apache/tooling-trusted-releases)`. Keeping
+the mapping here (and tested) means that if PonyMail ever adopts asfquart's
+``app.token_handler`` seam, or migrates onto Quart wholesale, the translation is
+a single reviewed function rather than a scattered rewrite. See
+``docs/asfquart_migration.md`` for the rationale and the step-by-step plan.
+
+Nothing in here imports asfquart -- it is not a dependency. We only produce
+dicts shaped the way ``asfquart.session.ClientSession`` expects and predicates
+shaped the way ``asfquart.auth.Requirements`` expects.
+"""
+
+import typing
+
+import plugins.token
+
+# asfquart stores per-session scope under ``session.metadata["scope"]`` (see its
+# personal_access_tokens.py example, which ATR follows). Mirror that key exactly
+# so a future asfquart token_handler can read our scopes without translation.
+SCOPE_METADATA_KEY = "scope"
+
+
+def to_asfquart_session(session: typing.Any) -> dict:
+    """Render a PonyMail ``SessionObject`` as an asfquart session dict.
+
+    The returned dict matches the fields ``asfquart.session.ClientSession``
+    reads (``uid``, ``email``, ``fullname``, ``roleaccount``, ``metadata`` ...).
+    An asfquart ``token_handler`` callback could return this dict verbatim.
+
+    Mapping notes -- PonyMail tracks a narrower identity than asfquart's
+    LDAP/OAuth-backed session, so some asfquart fields have no PonyMail source:
+
+      * ``roleaccount``: True for a token (Bearer) session. This matches
+        asfquart's own PAT example, which models personal access tokens as role
+        accounts; an interactive cookie session maps to a normal user (False).
+      * ``isRoot``: mapped from PonyMail's ``admin`` flag, the closest analogue
+        to asfquart's infra-root membership.
+      * ``isMember`` / ``isChair`` / ``pmcs`` / ``projects`` / ``mfa``: PonyMail
+        does not track ASF org roles, so these stay at their empty defaults.
+        A Quart/asfquart deployment would populate them from the OAuth payload.
+      * ``scope``: a token session carries the token's granted scopes; an
+        interactive session is unrestricted, represented here as all scopes.
+    """
+    creds = getattr(session, "credentials", None)
+    is_token = bool(getattr(session, "token", False))
+    scopes = (
+        list(getattr(session, "token_scopes", None) or [])
+        if is_token
+        else list(plugins.token.ALL_SCOPES)
+    )
+    return {
+        "uid": getattr(creds, "uid", "") if creds else "",
+        "email": getattr(creds, "email", "") if creds else "",
+        "fullname": getattr(creds, "name", "") if creds else "",
+        "isMember": False,
+        "isChair": False,
+        "isRoot": bool(getattr(creds, "admin", False)) if creds else False,
+        "pmcs": [],
+        "projects": [],
+        "mfa": False,
+        "roleaccount": is_token,
+        "metadata": {
+            SCOPE_METADATA_KEY: scopes,
+            # Extra PonyMail context an asfquart consumer can ignore but that we
+            # keep so no information is lost across the translation.
+            "api_token": is_token,
+            "oauth_provider": getattr(creds, "oauth_provider", "") if creds else "",
+            "authoritative": bool(getattr(creds, "authoritative", False)) if creds else False,
+        },
+    }
+
+
+def scope_requirement(scope: str) -> typing.Callable[[dict], typing.Tuple[bool, str]]:
+    """Build an asfquart-style ``Requirements`` predicate for a token scope.
+
+    asfquart gates endpoints with ``@asfquart.auth.require(Requirements.foo)``,
+    where each requirement is ``fn(client_session) -> (passes, message)``. This
+    returns such a predicate for one of our token scopes, so the very same
+    per-endpoint rule enforced today by ``main.py`` via ``token.token_allows``
+    could instead be attached as::
+
+        @asfquart.auth.require(scope_requirement(token.required_scope(handler)))
+
+    once PonyMail runs under asfquart. An interactive (non-token) session, which
+    ``to_asfquart_session`` renders with all scopes, satisfies every scope -
+    matching today's rule that only token sessions are scope-restricted.
+    """
+
+    message = "This API token lacks the '%s' scope required for this endpoint." % scope
+
+    def _requirement(client_session: dict) -> typing.Tuple[bool, str]:
+        metadata = (client_session or {}).get("metadata") or {}
+        granted = metadata.get(SCOPE_METADATA_KEY) or []
+        return scope in granted, message
+
+    _requirement.__name__ = "scope_%s" % scope
+    return _requirement

--- a/server/plugins/auditlog.py
+++ b/server/plugins/auditlog.py
@@ -69,8 +69,15 @@ async def view(
             yield AuditLogEntry(doc["_source"])
 
 
-async def add_entry(session: plugins.session.SessionObject, action: str, target: str, lid: str, log: str) -> None:
-    """ Adds an entry to the audit log"""
+async def add_entry(
+    session: plugins.session.SessionObject, action: str, target: str, lid: str, log: str, refresh="wait_for"
+) -> None:
+    """ Adds an entry to the audit log.
+
+    ``refresh`` controls the ElasticSearch refresh policy; callers that do not
+    need the entry to be immediately searchable can pass ``False`` to avoid
+    blocking on a refresh cycle.
+    """
 
     # Default log entries based on type
     if not log and action == "delete":
@@ -90,5 +97,5 @@ async def add_entry(session: plugins.session.SessionObject, action: str, target:
             "lid": lid,
             "log": log,
         },
-        refresh='wait_for',
+        refresh=refresh,
     )

--- a/server/plugins/background.py
+++ b/server/plugins/background.py
@@ -29,6 +29,7 @@ from elasticsearch import VERSION as ES_VERSION
 import plugins.configuration
 import plugins.server
 import plugins.database
+import plugins.token
 
 PYPONY_RE_PREFIX = re.compile(r"^([a-zA-Z]+:\s*)+")
 ACTIVITY_TIMESPAN = "now-90d"  # How far back to look for "current" activity in lists
@@ -227,6 +228,20 @@ async def get_data(server: plugins.server.BaseServer):
                 "Could not fetch activity data - database down or not connected: %s"
                 % e
             )
+    # Housekeeping: purge expired API tokens so abandoned ones do not pile up,
+    # and drop stale entries from the optional in-memory token auth cache.
+    if server.config.tokens.enabled:
+        async with ProgTimer("Purging expired API tokens"):
+            now = int(time.time())
+            try:
+                db = plugins.database.Database(server.config.database)
+                await plugins.token.purge_expired_tokens(db, now)
+                await db.client.close()
+            except plugins.database.DBError as e:
+                print("Could not purge expired tokens: %s" % e)
+            expired = [key for key, val in server.data.token_cache.items() if val["expiry"] <= now]
+            for key in expired:
+                server.data.token_cache.pop(key, None)
 
 async def run_tasks(server: plugins.server.BaseServer) -> None:
     """

--- a/server/plugins/configuration.py
+++ b/server/plugins/configuration.py
@@ -74,6 +74,37 @@ class OAuthConfig:
         self.providers = subyaml.get("providers", {})
 
 
+class TokensConfig:
+    """Configuration for long-term API tokens (see plugins/token.py)."""
+
+    enabled: bool
+    default_age: int  # seconds; 0 == token never expires
+    max_age: int  # seconds; 0 == no upper bound enforced
+    max_tokens: int  # per-account cap on the number of live tokens
+    cache_ttl: int  # seconds to cache token auth in memory; 0 == disabled
+    cache_max: int  # max number of entries in the in-memory token auth cache
+    revoke_on_identity_change: bool  # drop a user's tokens when their OAuth identity changes
+
+    def __init__(self, subyaml: dict):
+        self.enabled = bool(subyaml.get("enabled", False))
+        # Default to a 30-day lifetime when the user does not request one.
+        self.default_age = int(subyaml.get("default_lifetime", 86400 * 30))
+        self.max_age = int(subyaml.get("max_lifetime", 0))
+        self.max_tokens = int(subyaml.get("max_tokens", 25))
+        # Optional in-memory cache of token auth to avoid a database lookup on
+        # every request. Disabled by default (0) because caching delays the
+        # effect of revocation/expiry by up to this many seconds.
+        self.cache_ttl = int(subyaml.get("cache_ttl", 0))
+        # Upper bound on cache entries; the cache is flushed if it is exceeded,
+        # so token auth cannot grow memory without limit.
+        self.cache_max = int(subyaml.get("cache_max", 10000))
+        # When a user logs in and their OAuth identity/permissions differ from
+        # what was stored (e.g. after a credential reset or a group-membership
+        # change upstream), automatically revoke all of that user's API tokens
+        # so credentials minted under the old identity cannot be reused.
+        self.revoke_on_identity_change = bool(subyaml.get("revoke_on_identity_change", True))
+
+
 class DBConfig:
     dburl: str
     hostname: str
@@ -103,6 +134,7 @@ class Configuration:
     tasks: TaskConfig
     oauth: OAuthConfig
     ui: UIConfig
+    tokens: TokensConfig
 
     def __init__(self, yml: dict):
         self.server = ServerConfig(yml.get("server", {}))
@@ -110,6 +142,7 @@ class Configuration:
         self.tasks = TaskConfig(yml.get("tasks", {}))
         self.oauth = OAuthConfig(yml.get("oauth", {}))
         self.ui = UIConfig(yml.get("ui", {}))
+        self.tokens = TokensConfig(yml.get("tokens", {}))
 
 
 class InterData:
@@ -120,8 +153,10 @@ class InterData:
     lists: dict
     sessions: dict
     activity: dict
+    token_cache: dict
 
     def __init__(self):
         self.lists = {}
         self.sessions = {}
         self.activity = {}
+        self.token_cache = {}  # token hash -> cached auth (only used if tokens.cache_ttl > 0)

--- a/server/plugins/database.py
+++ b/server/plugins/database.py
@@ -38,6 +38,7 @@ class DBNames:
         self.db_attachment = f"{dbprefix}-attachment"
         self.db_account = f"{dbprefix}-account"
         self.db_session = f"{dbprefix}-session"
+        self.db_token = f"{dbprefix}-token"
         self.db_notification = f"{dbprefix}-notification"
         self.db_auditlog = f"{dbprefix}-auditlog"
 
@@ -82,6 +83,20 @@ class Database:
         if not index:
             index = self.dbs.db_mbox
         res = await self.client.get(index=index, **kwargs)
+        return res
+
+    async def count(self, index="", **kwargs):
+        if not index:
+            index = self.dbs.db_mbox
+        res = await self.client.count(index=index, **kwargs)
+        return res
+
+    async def delete_by_query(self, index="", **kwargs):
+        # This bulk-deletes documents, so refuse to run without an explicit
+        # index rather than defaulting to a data index (or, worse, all indices).
+        if not index:
+            raise ValueError("delete_by_query requires an explicit index")
+        res = await self.client.delete_by_query(index=index, **kwargs)
         return res
 
     async def delete(self, index="", **kwargs):

--- a/server/plugins/session.py
+++ b/server/plugins/session.py
@@ -26,6 +26,7 @@ import aiohttp.web
 
 import plugins.database
 import plugins.server
+import plugins.token
 import copy
 
 FOAL_MAX_SESSION_AGE = 86400 * 7  # Max 1 week between visits before voiding a session
@@ -71,6 +72,9 @@ class SessionObject:
     remote: str
     host: str
     server: plugins.server.BaseServer
+    token: bool  # True if this session was authenticated via a long-term API token
+    token_scopes: typing.List[str]  # scopes granted to the API token (token auth only)
+    token_invalid: bool  # True if a bearer token was presented but is invalid/expired
 
     def __init__(self, server: plugins.server.BaseServer, **kwargs):
         self.database = None
@@ -78,6 +82,9 @@ class SessionObject:
         self.created = int(time.time())
         self.host = "??"
         self.remote = "??"
+        self.token = False
+        self.token_scopes = []
+        self.token_invalid = False
         if kwargs:
             self.last_accessed = kwargs.get("last_accessed", 0)
             self.credentials = SessionCredentials(kwargs.get("credentials"))
@@ -96,6 +103,15 @@ async def get_session(
     session_id = None
     session = None
     now = int(time.time())
+
+    # Long-term API token auth (Authorization: Bearer <token>).
+    # Tokens bypass the cookie flow entirely and are not cached in memory;
+    # each request is validated against the database.
+    if server.config.tokens.enabled:
+        bearer = plugins.token.token_from_request(request)
+        if bearer:
+            return await get_token_session(server, request, bearer, now)
+
     if request.headers.get("cookie"):
         for cookie_header in request.headers.getall("cookie"):
             cookies: http.cookies.SimpleCookie = http.cookies.SimpleCookie(
@@ -176,6 +192,111 @@ async def get_session(
 
         except plugins.database.DBError:
             pass
+    return session
+
+
+def _apply_token_credentials(
+    session: SessionObject, cid: typing.Optional[str], creds: dict, scopes: typing.List[str], now: int
+) -> None:
+    """Populate a session object from resolved token credentials."""
+    session.cid = cid
+    session.last_accessed = now
+    session.token = True
+    session.token_scopes = scopes
+    session.credentials = SessionCredentials(creds)
+
+
+def _cache_put(cache: dict, cache_max: int, key: str, entry: dict) -> None:
+    """Insert an entry into the bounded token auth cache.
+
+    When the cache is full we evict the oldest entries one at a time rather than
+    flushing the whole cache (which would trigger a burst of database lookups).
+    Every entry shares the same TTL, so the oldest inserted entry is also the
+    one nearest to expiry. Re-inserting an existing key moves it to the newest
+    position so insertion order keeps tracking age.
+    """
+    cache.pop(key, None)
+    while cache and len(cache) >= cache_max:
+        cache.pop(next(iter(cache)))
+    cache[key] = entry
+
+
+async def get_token_session(
+    server: plugins.server.BaseServer,
+    request: aiohttp.web.BaseRequest,
+    bearer: str,
+    now: int,
+) -> SessionObject:
+    """Build a session from a long-term API token.
+
+    If the token is unknown or expired, the returned session has
+    ``token_invalid`` set so the request layer can reject it with a clear error
+    rather than silently downgrading to anonymous access.
+    """
+    session = SessionObject(server)
+    session.database = await server.dbpool.get()
+    session.host = request.headers.get("X-Forwarded-Host", request.host or "??")
+    session.remote = request.remote or "??"
+
+    tid = plugins.token.hash_token(bearer)
+    cache_ttl = server.config.tokens.cache_ttl
+
+    # Optional short-lived cache: skip the two database reads when this token was
+    # validated within cache_ttl seconds. Disabled by default (cache_ttl == 0),
+    # since caching delays the effect of revocation/expiry by up to cache_ttl.
+    if cache_ttl > 0:
+        cached = server.data.token_cache.get(tid)
+        if cached:
+            if cached["expiry"] > now:
+                _apply_token_credentials(session, cached["cid"], cached["creds"], cached["scopes"], now)
+                return session
+            # Always drop an expired entry when we touch it, so stale credentials
+            # never linger in the cache; fall through to a fresh lookup.
+            server.data.token_cache.pop(tid, None)
+
+    token_doc = await plugins.token.lookup_token(session.database, bearer)
+    if not token_doc:
+        session.token_invalid = True
+        server.data.token_cache.pop(tid, None)  # drop any now-stale cache entry
+        return session
+
+    cid = token_doc.get("cid")
+    try:
+        account_doc = await session.database.get(session.database.dbs.db_account, id=cid)
+    except plugins.database.DBError:
+        session.token_invalid = True
+        return session
+
+    creds = account_doc["_source"]["credentials"]
+    internal = account_doc["_source"]["internal"]
+    # Distinguish a missing "scopes" field (legacy token from before scoping ->
+    # full access, so it keeps working) from an explicit empty list (-> no
+    # access). Using `or` here would fail open and treat [] as full access.
+    stored_scopes = token_doc.get("scopes")
+    scopes = list(plugins.token.ALL_SCOPES) if stored_scopes is None else stored_scopes
+    creds["authoritative"] = internal.get("oauth_provider") in server.config.oauth.authoritative_domains
+    creds["oauth_provider"] = internal.get("oauth_provider", OAUTH_PROVIDER_DEFAULT)
+    creds["oauth_data"] = internal.get("oauth_data", {})
+    creds["admin"] = creds["authoritative"] and creds.get("email") in server.config.oauth.admins
+    _apply_token_credentials(session, cid, creds, scopes, now)
+
+    # Populate the optional cache (bounded to avoid unbounded memory growth).
+    if cache_ttl > 0:
+        _cache_put(
+            server.data.token_cache,
+            server.config.tokens.cache_max,
+            tid,
+            {"expiry": now + cache_ttl, "cid": cid, "creds": creds, "scopes": scopes},
+        )
+
+    # Record usage, but no more than once per TOKEN_UPDATE_INTERVAL to avoid a
+    # database write on every single API call.
+    if (now - token_doc.get("last_used", 0)) > plugins.token.TOKEN_UPDATE_INTERVAL:
+        try:
+            await plugins.token.touch_token(session.database, token_doc["id"], now)
+        except plugins.database.DBError:
+            pass
+
     return session
 
 

--- a/server/plugins/token.py
+++ b/server/plugins/token.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Long-term API token handling for Pony Mail codename Foal.
+
+Tokens let a user authenticate to the API programmatically by sending an
+``Authorization: Bearer <token>`` header, without going through the interactive
+OAuth flow and without being subject to the short session-cookie lifetime.
+
+Security notes:
+  * The raw token is shown to the user exactly once, at creation time.
+  * Only a SHA-256 digest of the token is stored server-side, so a database
+    leak does not, by itself, expose usable credentials.
+  * A token grants the same access as the account that created it (including
+    any private lists that account can reach).
+"""
+
+import hashlib
+import json
+import secrets
+import time
+import typing
+
+import aiohttp.web
+
+import plugins.database
+
+# A short, greppable prefix so tokens are recognisable in logs and headers.
+TOKEN_PREFIX = "pmt_"  # "Pony Mail Token"
+# 32 bytes == 256 bits of entropy (~43 url-safe characters).
+TOKEN_NBYTES = 32
+# Only rewrite a token's "last_used" timestamp at most this often (seconds).
+TOKEN_UPDATE_INTERVAL = 3600
+
+# Token scopes. A token's effective access is the intersection of its owner's
+# account permissions and its scopes, so a scope can only *restrict* access -
+# it never grants more than the underlying account already has.
+SCOPE_READ = "read"  # search + fetch emails/threads/sources/mbox, read preferences
+SCOPE_WRITE = "write"  # send email (compose)
+SCOPE_ADMIN = "admin"  # administrative operations (hide/delete/edit)
+ALL_SCOPES = (SCOPE_READ, SCOPE_WRITE, SCOPE_ADMIN)
+DEFAULT_SCOPES = (SCOPE_READ,)  # least privilege when the caller does not choose
+
+# Which scope each API endpoint requires. Endpoints not listed require read.
+_WRITE_ENDPOINTS = frozenset({"compose"})
+_ADMIN_ENDPOINTS = frozenset({"mgmt"})
+
+
+def required_scope(handler: str) -> str:
+    """Return the token scope required to reach the given API endpoint."""
+    if handler in _ADMIN_ENDPOINTS:
+        return SCOPE_ADMIN
+    if handler in _WRITE_ENDPOINTS:
+        return SCOPE_WRITE
+    return SCOPE_READ
+
+
+def normalize_scopes(raw: typing.Any) -> typing.List[str]:
+    """Coerce caller-supplied scopes into a validated, de-duplicated list.
+
+    Accepts a list/tuple or a space/comma-separated string. Unknown scopes are
+    dropped; falls back to DEFAULT_SCOPES when nothing valid remains.
+    """
+    if isinstance(raw, str):
+        items = raw.replace(",", " ").split()
+    elif isinstance(raw, (list, tuple)):
+        items = [str(x) for x in raw]
+    else:
+        items = []
+    wanted = {i.strip().lower() for i in items}
+    # Keep canonical order, drop unknowns/duplicates.
+    scopes = [s for s in ALL_SCOPES if s in wanted]
+    return scopes or list(DEFAULT_SCOPES)
+
+
+def token_allows(session: typing.Any, handler: str) -> bool:
+    """Whether a (possibly token-authenticated) session may reach an endpoint.
+
+    Cookie (non-token) sessions are never restricted here. A token session must
+    carry the scope the endpoint requires.
+    """
+    if not getattr(session, "token", False):
+        return True
+    return required_scope(handler) in (getattr(session, "token_scopes", None) or [])
+
+
+def generate_token() -> str:
+    """Return a fresh random token string (the secret shown to the user once)."""
+    return TOKEN_PREFIX + secrets.token_urlsafe(TOKEN_NBYTES)
+
+
+def hash_token(token: str) -> str:
+    """Return the storage id for a token: its SHA-256 hex digest.
+
+    We store only this digest, never the raw token.
+    """
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def token_from_request(request: aiohttp.web.BaseRequest) -> typing.Optional[str]:
+    """Extract a bearer token from the Authorization header, or None."""
+    auth = request.headers.get("Authorization")
+    if not auth:
+        return None
+    parts = auth.split(" ", 1)
+    if len(parts) == 2 and parts[0].lower() == "bearer":
+        candidate = parts[1].strip()
+        if candidate.startswith(TOKEN_PREFIX):
+            return candidate
+    return None
+
+
+async def create_token(
+    database: plugins.database.Database,
+    cid: str,
+    description: str,
+    expires: int,
+    scopes: typing.Sequence[str],
+) -> dict:
+    """Create and persist a new token for account ``cid``.
+
+    ``expires`` is an absolute epoch timestamp, or 0 for a token that never
+    expires. ``scopes`` restricts what the token may do. Returns the stored
+    metadata plus the raw ``token`` secret, which is the only time the raw
+    token is ever available.
+    """
+    raw = generate_token()
+    tid = hash_token(raw)
+    now = int(time.time())
+    doc = {
+        "id": tid,
+        "cid": cid,
+        "description": description[:256],
+        "created": now,
+        "expires": int(expires),
+        "last_used": 0,
+        "scopes": list(scopes),
+    }
+    await database.index(index=database.dbs.db_token, id=tid, body=doc, refresh="wait_for")
+    result = dict(doc)
+    result.pop("cid", None)  # internal linkage, not needed by the caller
+    result["token"] = raw
+    return result
+
+
+async def list_tokens(database: plugins.database.Database, cid: str) -> typing.List[dict]:
+    """Return metadata (never the raw secret) for all tokens owned by ``cid``."""
+    res = await database.search(
+        index=database.dbs.db_token,
+        size=100,
+        sort="created:desc",
+        body={"query": {"term": {"cid": cid}}},
+    )
+    out = []
+    for hit in res["hits"]["hits"]:
+        src = hit["_source"]
+        src.pop("cid", None)  # do not echo internal account linkage
+        out.append(src)
+    return out
+
+
+async def revoke_token(database: plugins.database.Database, cid: str, tid: str) -> bool:
+    """Delete token ``tid`` if it belongs to ``cid``. Returns True on success."""
+    try:
+        doc = await database.get(index=database.dbs.db_token, id=tid)
+    except plugins.database.DBError:
+        return False
+    # Only allow a user to revoke their own tokens.
+    if doc["_source"].get("cid") != cid:
+        return False
+    await database.delete(index=database.dbs.db_token, id=tid, refresh="wait_for")
+    return True
+
+
+async def lookup_token(database: plugins.database.Database, raw_token: str) -> typing.Optional[dict]:
+    """Resolve a raw token to its stored doc, or None if missing/expired.
+
+    Expired tokens are deleted as a side effect so they cannot be reused.
+    """
+    tid = hash_token(raw_token)
+    try:
+        doc = await database.get(index=database.dbs.db_token, id=tid)
+    except plugins.database.DBError:
+        return None
+    src = doc["_source"]
+    expires = src.get("expires") or 0
+    if expires and int(time.time()) > expires:
+        try:
+            await database.delete(index=database.dbs.db_token, id=tid)
+        except plugins.database.DBError:
+            pass
+        return None
+    return src
+
+
+async def touch_token(database: plugins.database.Database, tid: str, now: int) -> None:
+    """Record that a token was just used (callers should throttle this)."""
+    await database.update(index=database.dbs.db_token, id=tid, body={"doc": {"last_used": now}})
+
+
+async def count_tokens(database: plugins.database.Database, cid: str) -> int:
+    """Exact number of tokens owned by ``cid``.
+
+    Used for enforcing the per-user cap: unlike list_tokens() this is not bounded
+    by a search page size, so the cap holds even if it is configured above 100.
+    """
+    res = await database.count(index=database.dbs.db_token, body={"query": {"term": {"cid": cid}}})
+    return int(res.get("count", 0))
+
+
+async def purge_expired_tokens(database: plugins.database.Database, now: int) -> int:
+    """Delete every token whose expiry has passed. Returns the number deleted.
+
+    Tokens with ``expires == 0`` never expire and are left untouched. This is a
+    housekeeping sweep so abandoned expired tokens do not accumulate in the
+    index (they are also removed lazily by lookup_token on next use).
+    """
+    res = await database.delete_by_query(
+        index=database.dbs.db_token,
+        body={"query": {"range": {"expires": {"gt": 0, "lt": now}}}},
+        conflicts="proceed",
+        ignore=(404,),  # index may not exist yet; nothing to purge
+    )
+    return int(res.get("deleted", 0))
+
+
+async def purge_tokens_for_cid(database: plugins.database.Database, cid: str) -> int:
+    """Delete *every* token owned by account ``cid``. Returns the number deleted.
+
+    Unlike revoke_token (which kills one specific token a user owns), this wipes
+    an account's entire token set at once. It backs both the admin ``token_purge``
+    action and the automatic revocation triggered when a user's upstream identity
+    changes, so a token minted before a credential reset cannot outlive it.
+    """
+    if not cid:
+        return 0
+    res = await database.delete_by_query(
+        index=database.dbs.db_token,
+        body={"query": {"term": {"cid": cid}}},
+        conflicts="proceed",
+        ignore=(404,),  # index may not exist yet; nothing to purge
+    )
+    return int(res.get("deleted", 0))
+
+
+# OAuth payload keys that vary between logins without reflecting a change in the
+# user's identity or permissions (bearer/refresh secrets, token lifetimes, and
+# per-exchange nonces). They are ignored when deciding whether a login
+# represents a changed "setup", so an ordinary re-login does not needlessly
+# invalidate a user's tokens.
+_IDENTITY_VOLATILE_KEYS = frozenset(
+    {
+        "access_token",
+        "refresh_token",
+        "id_token",
+        "token",
+        "token_type",
+        "expires",
+        "expires_in",
+        "exp",
+        "iat",
+        "nbf",
+        "iss",
+        "aud",
+        "nonce",
+        "state",
+        "code",
+        "scope",
+        "session_state",
+    }
+)
+
+
+def identity_fingerprint(oauth_data: typing.Any) -> str:
+    """Stable digest of the identity-relevant parts of an OAuth payload.
+
+    Everything the provider returns *except* the volatile secret/timestamp keys
+    (see ``_IDENTITY_VOLATILE_KEYS``) is treated as identity: email, uid, and —
+    crucially for permissions — any group/project/role membership the provider
+    reports. Two payloads that describe the same person with the same
+    entitlements therefore share a fingerprint even across separate logins.
+    """
+    if not isinstance(oauth_data, dict):
+        oauth_data = {}
+    material = {k: v for k, v in oauth_data.items() if k not in _IDENTITY_VOLATILE_KEYS}
+    canonical = json.dumps(material, sort_keys=True, default=str, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def oauth_setup_changed(old_oauth_data: typing.Any, new_oauth_data: typing.Any) -> bool:
+    """Whether a fresh OAuth login differs materially from the stored one.
+
+    Used to auto-revoke tokens when the upstream account changes (e.g. a
+    credential reset or a change in group membership). Errs toward *True*: any
+    difference outside the volatile keys is treated as a change, so tokens are
+    dropped rather than kept when in doubt.
+    """
+    return identity_fingerprint(old_oauth_data) != identity_fingerprint(new_oauth_data)

--- a/server/ponymail.yaml.example
+++ b/server/ponymail.yaml.example
@@ -14,6 +14,19 @@ database:
 tasks:
   refresh_rate:  150                  # Background indexer run interval, in seconds
 
+# Long-term API tokens. Logged-in users can mint tokens and authenticate to the
+# API programmatically with 'Authorization: Bearer <token>'.
+tokens:
+  enabled:          false             # Allow creating/using API tokens at all
+  default_lifetime: 2592000           # Default token lifetime in seconds (0 = never expires). Default: 30 days
+  max_lifetime:     0                 # Upper bound on lifetime in seconds (0 = no limit)
+  max_tokens:       25                # Maximum number of live tokens per user
+  cache_ttl:        0                 # Seconds to cache token auth in memory (0 = disabled). >0 trades
+                                      # immediate revocation for fewer database lookups on hot API paths.
+  cache_max:        10000             # Max entries in the token auth cache (flushed if exceeded)
+  revoke_on_identity_change: true      # Auto-revoke a user's tokens when their OAuth identity/permissions
+                                       # change on login (e.g. after a credential reset). Default: true
+
 ui:
   wordcloud:       true
   mailhost:        localhost # domain[:port] - default port is 25

--- a/test/test_asfquart_compat.py
+++ b/test/test_asfquart_compat.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To be run as: python3 -m pytest test/test_asfquart_compat.py
+# This ensures sys.path is set up correctly.
+
+import os
+import sys
+
+# The server imports its plugins as a top-level "plugins" package (it runs with
+# the server/ directory as the working dir), so put server/ on the path here too.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir, "server"))
+
+import plugins.asfquart_compat as compat  # noqa: E402
+import plugins.token as token  # noqa: E402
+
+
+class _FakeCreds:
+    def __init__(self, uid="", name="", email="", admin=False, authoritative=False, oauth_provider=""):
+        self.uid = uid
+        self.name = name
+        self.email = email
+        self.admin = admin
+        self.authoritative = authoritative
+        self.oauth_provider = oauth_provider
+
+
+class _FakeSession:
+    """Minimal stand-in for a SessionObject."""
+
+    def __init__(self, is_token, scopes=None, credentials=None):
+        self.token = is_token
+        self.token_scopes = scopes or []
+        self.credentials = credentials
+
+
+def test_token_session_maps_to_asfquart_shape():
+    creds = _FakeCreds(uid="alice", name="Alice A", email="alice@apache.org", oauth_provider="google")
+    session = _FakeSession(True, ["read", "write"], creds)
+    out = compat.to_asfquart_session(session)
+
+    # Identity fields carry across.
+    assert out["uid"] == "alice"
+    assert out["fullname"] == "Alice A"
+    assert out["email"] == "alice@apache.org"
+    # A token session is modelled as a role account (matches asfquart's PAT example).
+    assert out["roleaccount"] is True
+    # Scopes live under metadata["scope"] exactly like asfquart expects.
+    assert out["metadata"][compat.SCOPE_METADATA_KEY] == ["read", "write"]
+    assert out["metadata"]["api_token"] is True
+    assert out["metadata"]["oauth_provider"] == "google"
+
+
+def test_interactive_session_is_unrestricted_and_not_a_roleaccount():
+    creds = _FakeCreds(uid="bob", email="bob@apache.org", admin=True)
+    session = _FakeSession(False, credentials=creds)
+    out = compat.to_asfquart_session(session)
+
+    assert out["roleaccount"] is False
+    # An interactive session is not scope-restricted -> all scopes present.
+    assert out["metadata"][compat.SCOPE_METADATA_KEY] == list(token.ALL_SCOPES)
+    # PonyMail "admin" maps to asfquart's isRoot, the closest analogue.
+    assert out["isRoot"] is True
+
+
+def test_missing_credentials_yield_empty_but_valid_shape():
+    out = compat.to_asfquart_session(_FakeSession(False, credentials=None))
+    assert out["uid"] == ""
+    assert out["email"] == ""
+    assert out["isRoot"] is False
+    # Even with no credentials the required asfquart keys exist.
+    for key in ("uid", "email", "fullname", "isMember", "isChair", "isRoot", "roleaccount", "metadata"):
+        assert key in out
+
+
+def test_scope_requirement_mirrors_token_allows():
+    # For a token session, the asfquart-style requirement must agree with the
+    # native token.token_allows() decision for every endpoint/scope pairing.
+    for scopes in ([], ["read"], ["read", "write"], list(token.ALL_SCOPES)):
+        session = _FakeSession(True, scopes)
+        asf = compat.to_asfquart_session(session)
+        for handler in ("stats", "compose", "mgmt"):
+            required = token.required_scope(handler)
+            passes, message = compat.scope_requirement(required)(asf)
+            assert passes == token.token_allows(session, handler)
+            if not passes:
+                assert required in message
+
+
+def test_scope_requirement_predicate_is_named():
+    # asfquart derives error routing from the requirement's __name__; make sure
+    # ours is stable and scope-specific rather than the generic closure name.
+    req = compat.scope_requirement("admin")
+    assert req.__name__ == "scope_admin"

--- a/test/test_token.py
+++ b/test/test_token.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To be run as: python3 -m pytest test/test_token.py
+# This ensures sys.path is set up correctly.
+
+import hashlib
+import os
+import sys
+
+# The server imports its plugins as a top-level "plugins" package (it runs with
+# the server/ directory as the working dir), so put server/ on the path here too.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir, "server"))
+
+import plugins.token as token  # noqa: E402
+
+
+class _FakeRequest:
+    """Minimal stand-in for an aiohttp request exposing .headers.get()."""
+
+    def __init__(self, headers=None):
+        self.headers = headers or {}
+
+
+def test_generate_token_is_prefixed_and_unique():
+    a = token.generate_token()
+    b = token.generate_token()
+    assert a.startswith(token.TOKEN_PREFIX)
+    assert b.startswith(token.TOKEN_PREFIX)
+    assert a != b  # random -> effectively never collide
+    # Prefix + url-safe secret should be comfortably long.
+    assert len(a) > len(token.TOKEN_PREFIX) + 20
+
+
+def test_hash_token_is_stable_sha256():
+    raw = token.generate_token()
+    assert token.hash_token(raw) == hashlib.sha256(raw.encode("utf-8")).hexdigest()
+    # Same input -> same digest, different input -> different digest.
+    assert token.hash_token(raw) == token.hash_token(raw)
+    assert token.hash_token(raw) != token.hash_token(raw + "x")
+
+
+def test_hash_token_does_not_contain_raw_secret():
+    raw = token.generate_token()
+    assert raw not in token.hash_token(raw)
+
+
+def test_token_from_request_valid_bearer():
+    raw = token.generate_token()
+    req = _FakeRequest({"Authorization": "Bearer %s" % raw})
+    assert token.token_from_request(req) == raw
+
+
+def test_token_from_request_is_scheme_case_insensitive():
+    raw = token.generate_token()
+    req = _FakeRequest({"Authorization": "bearer %s" % raw})
+    assert token.token_from_request(req) == raw
+
+
+def test_token_from_request_rejects_missing_and_malformed():
+    assert token.token_from_request(_FakeRequest({})) is None
+    # No "Bearer " scheme
+    assert token.token_from_request(_FakeRequest({"Authorization": "Basic abc"})) is None
+    # Bearer but not one of our tokens (wrong prefix)
+    assert token.token_from_request(_FakeRequest({"Authorization": "Bearer abc123"})) is None
+    # Empty value
+    assert token.token_from_request(_FakeRequest({"Authorization": ""})) is None
+
+
+class _FakeSession:
+    """Minimal stand-in for a SessionObject for scope checks."""
+
+    def __init__(self, is_token, scopes=None):
+        self.token = is_token
+        self.token_scopes = scopes or []
+
+
+def test_required_scope_maps_endpoints():
+    assert token.required_scope("compose") == token.SCOPE_WRITE
+    assert token.required_scope("mgmt") == token.SCOPE_ADMIN
+    # Anything else is a read operation.
+    for h in ("stats", "email", "thread", "mbox", "preferences", "unknown"):
+        assert token.required_scope(h) == token.SCOPE_READ
+
+
+def test_normalize_scopes_parsing_and_defaults():
+    # String forms (space and comma separated) and lists all work.
+    assert token.normalize_scopes("read write") == ["read", "write"]
+    assert token.normalize_scopes("write,read") == ["read", "write"]  # canonical order
+    assert token.normalize_scopes(["admin", "read"]) == ["read", "admin"]
+    # Unknown scopes are dropped; duplicates collapsed.
+    assert token.normalize_scopes("read read bogus") == ["read"]
+    # Empty / invalid input falls back to the least-privilege default.
+    assert token.normalize_scopes("") == list(token.DEFAULT_SCOPES)
+    assert token.normalize_scopes("bogus") == list(token.DEFAULT_SCOPES)
+    assert token.normalize_scopes(None) == list(token.DEFAULT_SCOPES)
+
+
+def test_every_endpoint_scope_is_classified():
+    """Guard against a new privileged endpoint being silently reachable by a
+    read-only token. required_scope() defaults unlisted endpoints to read, so
+    this test forces every endpoint to be classified on purpose: adding or
+    removing an endpoint file fails here until this map (and, for write/admin
+    endpoints, plugins/token.py) is updated.
+    """
+    endpoints_dir = os.path.join(os.path.dirname(__file__), os.pardir, "server", "endpoints")
+    modules = {f[:-3] for f in os.listdir(endpoints_dir) if f.endswith(".py") and f != "__init__.py"}
+
+    expected = {
+        "compose": token.SCOPE_WRITE,
+        "mgmt": token.SCOPE_ADMIN,
+        "oauth": token.SCOPE_READ,  # public login handshake; no archive privilege
+        "email": token.SCOPE_READ,
+        "thread": token.SCOPE_READ,
+        "source": token.SCOPE_READ,
+        "mbox": token.SCOPE_READ,
+        "stats": token.SCOPE_READ,
+        "preferences": token.SCOPE_READ,
+        "pminfo": token.SCOPE_READ,
+        "gravatar": token.SCOPE_READ,
+        "plain": token.SCOPE_READ,
+        "token": token.SCOPE_READ,  # management endpoint; token auth is blocked inside it anyway
+    }
+
+    assert modules == set(expected), (
+        "server/endpoints changed - classify the new/removed endpoint(s) in this test "
+        "and (for write/admin endpoints) in plugins/token.py: %s" % (modules ^ set(expected))
+    )
+    for name, scope in expected.items():
+        assert token.required_scope(name) == scope
+
+
+def test_token_allows_enforces_scopes():
+    # Cookie (non-token) sessions are never restricted here.
+    assert token.token_allows(_FakeSession(False), "compose") is True
+    assert token.token_allows(_FakeSession(False, []), "mgmt") is True
+
+    read_only = _FakeSession(True, ["read"])
+    assert token.token_allows(read_only, "stats") is True
+    assert token.token_allows(read_only, "compose") is False
+    assert token.token_allows(read_only, "mgmt") is False
+
+    writer = _FakeSession(True, ["read", "write"])
+    assert token.token_allows(writer, "compose") is True
+    assert token.token_allows(writer, "mgmt") is False
+
+    full = _FakeSession(True, list(token.ALL_SCOPES))
+    assert all(token.token_allows(full, h) for h in ("stats", "compose", "mgmt"))
+
+
+def test_token_cache_evicts_oldest_instead_of_flushing():
+    import plugins.session as session  # noqa: E402
+
+    cache: dict = {}
+    for i in range(3):
+        session._cache_put(cache, 3, "k%d" % i, {"n": i})
+    assert list(cache) == ["k0", "k1", "k2"]
+
+    # Over capacity -> evict the oldest entry only (k0), keep the rest.
+    session._cache_put(cache, 3, "k3", {"n": 3})
+    assert list(cache) == ["k1", "k2", "k3"]
+    assert len(cache) == 3
+
+    # Re-inserting an existing key refreshes its position to newest.
+    session._cache_put(cache, 3, "k1", {"n": 11})
+    assert list(cache) == ["k2", "k3", "k1"]
+    assert cache["k1"] == {"n": 11}
+
+    # ...so the next eviction drops k2, proving k1 was not treated as oldest.
+    session._cache_put(cache, 3, "k4", {"n": 4})
+    assert list(cache) == ["k3", "k1", "k4"]
+
+
+def test_identity_fingerprint_ignores_volatile_keys():
+    # Same person and permissions, but a fresh login returns new bearer secrets
+    # and timestamps -> the fingerprint must stay identical so we don't purge
+    # tokens on every ordinary re-login.
+    base = {"uid": "alice", "email": "alice@example.org", "isMember": True, "projects": ["foo", "bar"]}
+    login1 = {**base, "access_token": "aaa", "expires_in": 3600, "iat": 1000}
+    login2 = {**base, "access_token": "zzz", "expires_in": 7200, "iat": 2000}
+    assert token.identity_fingerprint(login1) == token.identity_fingerprint(login2)
+
+    # Non-dict / empty inputs are handled and compare equal.
+    assert token.identity_fingerprint(None) == token.identity_fingerprint({})
+
+
+def test_oauth_setup_changed_detects_permission_changes():
+    old = {"uid": "alice", "email": "alice@example.org", "projects": ["foo"], "access_token": "a"}
+
+    # Pure re-login (only volatile fields differ) -> not a change.
+    assert token.oauth_setup_changed(old, {**old, "access_token": "b", "iat": 42}) is False
+
+    # Gained a project membership -> change.
+    assert token.oauth_setup_changed(old, {**old, "projects": ["foo", "bar"]}) is True
+
+    # Email changed -> change.
+    assert token.oauth_setup_changed(old, {**old, "email": "alice@new.org"}) is True
+
+    # A first-ever login (no prior data) counts as a change vs a populated payload.
+    assert token.oauth_setup_changed({}, old) is True
+
+
+def test_purge_tokens_for_cid():
+    import asyncio
+
+    class _FakeDBs:
+        db_token = "ponymail-token"
+
+    class _FakeDB:
+        def __init__(self, deleted):
+            self.dbs = _FakeDBs()
+            self.calls = []
+            self._deleted = deleted
+
+        async def delete_by_query(self, index, body, **kwargs):
+            self.calls.append({"index": index, "body": body, "kwargs": kwargs})
+            return {"deleted": self._deleted}
+
+    db = _FakeDB(deleted=3)
+    n = asyncio.run(token.purge_tokens_for_cid(db, "cid123"))
+    assert n == 3
+    assert db.calls[0]["index"] == "ponymail-token"
+    assert db.calls[0]["body"] == {"query": {"term": {"cid": "cid123"}}}
+
+    # An empty cid must never issue a delete-everything query.
+    db2 = _FakeDB(deleted=999)
+    assert asyncio.run(token.purge_tokens_for_cid(db2, "")) == 0
+    assert db2.calls == []

--- a/tools/mappings.yaml
+++ b/tools/mappings.yaml
@@ -148,6 +148,23 @@ session:
       type: long
     cid:
       type: keyword
+token:
+  dynamic: strict
+  properties:
+    id:
+      type: keyword
+    cid:
+      type: keyword
+    description:
+      type: keyword
+    created:
+      type: long
+    expires:
+      type: long
+    last_used:
+      type: long
+    scopes:
+      type: keyword
 source:
   dynamic: strict
   properties:

--- a/tools/plugins/elastic.py
+++ b/tools/plugins/elastic.py
@@ -42,6 +42,7 @@ class Elastic:
     db_attachment:      str
     db_account:         str
     db_session:         str
+    db_token:           str
     db_notification:    str
     db_auditlog:        str
     dbname:             str
@@ -58,6 +59,7 @@ class Elastic:
         self.db_account = dbname + '-account'
         self.db_attachment = dbname + '-attachment'
         self.db_session = dbname + '-session'
+        self.db_token = dbname + '-token'
         self.db_notification = dbname + '-notification'
         self.db_auditlog = dbname + '-auditlog'
         self.db_version = 0

--- a/webui/js/source/preferences.js
+++ b/webui/js/source/preferences.js
@@ -93,6 +93,13 @@ function init_preferences(state, json) {
         prefsmenu.innerHTML = "";
 
 
+        if (G_ponymail_preferences.tokens && G_ponymail_preferences.tokens.enabled) {
+            let tokens = new HTML('a', {
+                href: "javascript:void(manage_tokens());"
+            }, "API Tokens");
+            prefsmenu.inject(new HTML('li', {}, tokens));
+        }
+
         let logout = new HTML('a', {
             href: "javascript:void(logout());"
         }, "Log out");

--- a/webui/js/source/tokens.js
+++ b/webui/js/source/tokens.js
@@ -1,0 +1,216 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+// Long-term API token management UI.
+// Talks to /api/token; see server/endpoints/token.py.
+
+// POST a JSON action to the token endpoint and return {status, json}.
+async function tokens_api(payload) {
+    let rv = await POST('%sapi/token.json'.format(G_apiURL), JSON.stringify(payload), {});
+    let js = {};
+    try {
+        js = await rv.json();
+    } catch (e) {
+        js = { okay: false, message: "Malformed server response." };
+    }
+    return { status: rv.status, json: js };
+}
+
+// Format an epoch (seconds) as a compact UTC date, or "never" when 0/empty.
+// The " UTC" suffix is dropped here and shown once in the column header instead.
+function tokens_fmt_date(epoch) {
+    if (!epoch) {
+        return "never";
+    }
+    return new Date(epoch * 1000.0).ISOBare().replace(' UTC', '');
+}
+
+// Entry point (wired into the user dropdown menu). Opens the modal and draws
+// the token management UI.
+function manage_tokens() {
+    modal("API Tokens", "", "help", true);
+    let body = document.getElementById('modal_text');
+    if (!body) {
+        return;
+    }
+    body.innerHTML = "";
+
+    body.inject(new HTML('p', {}, "API tokens let you authenticate to the API from scripts by sending an " +
+        "'Authorization: Bearer <token>' header. Scopes limit what a token can do; a token can never exceed " +
+        "your own account's access. Treat tokens like passwords."));
+
+    // Creation form
+    let form = new HTML('div', { class: 'token_create' });
+    let desc = new HTML('input', {
+        type: 'text',
+        id: 'token_desc',
+        placeholder: 'Description (e.g. "laptop backup script")',
+        style: { width: '260px' }
+    });
+    form.inject(desc);
+
+    // Scope selection (read is the least-privilege default). The admin scope is
+    // only offered to admin accounts - it would be inert for anyone else.
+    let scope_defs = [
+        ['read', 'Read archives (search, fetch, download mbox)', true],
+        ['write', 'Send email (compose)', false]
+    ];
+    let creds = (G_ponymail_preferences.login && G_ponymail_preferences.login.credentials) || {};
+    if (creds.admin) {
+        scope_defs.push(['admin', 'Administrative actions (hide / delete / edit)', false]);
+    }
+    let scopes = new HTML('div', { class: 'token_scopes', style: { margin: '6px 0' } });
+    for (let s of scope_defs) {
+        let cb = new HTML('input', { type: 'checkbox', id: 'token_scope_' + s[0], value: s[0] });
+        if (s[2]) {
+            cb.checked = true;
+        }
+        scopes.inject(new HTML('div', {}, new HTML('label', {}, [cb, " " + s[0] + " — " + s[1]])));
+    }
+    form.inject(scopes);
+
+    form.inject(new HTML('button', { onclick: 'create_token();' }, "Create token"));
+    body.inject(form);
+    body.inject(new HTML('hr'));
+
+    // List placeholder, filled asynchronously
+    body.inject(new HTML('div', { id: 'token_list' }, "Loading…"));
+    load_tokens();
+}
+
+// Fetch and render the current user's tokens into #token_list.
+async function load_tokens() {
+    let list = document.getElementById('token_list');
+    if (!list) {
+        return;
+    }
+    let res = await tokens_api({ action: 'list' });
+    list.innerHTML = "";
+    if (!res.json.okay) {
+        list.inject(new HTML('p', { style: { color: 'red' } }, res.json.message || "Could not load tokens."));
+        return;
+    }
+    let tokens = res.json.tokens || [];
+    if (tokens.length === 0) {
+        list.inject(new HTML('p', {}, "You have no API tokens yet."));
+        return;
+    }
+
+    // Theme-neutral colours so the table reads well in both light and dark skins.
+    let hairline = '1px solid rgba(128, 128, 128, 0.25)';
+    let table = new HTML('table', {
+        class: 'token_table',
+        style: { borderCollapse: 'collapse', width: '100%', marginTop: '8px', fontSize: '13px' }
+    });
+
+    let hrow = new HTML('tr');
+    for (let h of ['Description', 'Scopes', 'Created (UTC)', 'Expires (UTC)', 'Last used (UTC)', '']) {
+        hrow.inject(new HTML('th', {
+            style: {
+                textAlign: 'left',
+                padding: '6px 10px',
+                borderBottom: '2px solid rgba(128, 128, 128, 0.45)',
+                whiteSpace: 'nowrap'
+            }
+        }, h));
+    }
+    table.inject(hrow);
+
+    let cell = { padding: '6px 10px', borderBottom: hairline, verticalAlign: 'top' };
+    let nowrap = { padding: '6px 10px', borderBottom: hairline, verticalAlign: 'top', whiteSpace: 'nowrap' };
+    let idx = 0;
+    for (let t of tokens) {
+        let revoke = new HTML('button', {
+            onclick: "revoke_token('%s');".format(t.id),
+            style: { color: 'red', cursor: 'pointer' }
+        }, "Revoke");
+        let row = new HTML('tr', {
+            class: 'token_row',
+            style: (idx++ % 2) ? { background: 'rgba(128, 128, 128, 0.06)' } : {}
+        }, [
+            new HTML('td', { style: cell }, t.description || ""),
+            new HTML('td', { style: nowrap }, (t.scopes || []).join(', ') || "read"),
+            new HTML('td', { style: nowrap }, tokens_fmt_date(t.created)),
+            new HTML('td', { style: nowrap }, tokens_fmt_date(t.expires)),
+            new HTML('td', { style: nowrap }, tokens_fmt_date(t.last_used)),
+            new HTML('td', { style: { padding: '6px 10px', borderBottom: hairline, textAlign: 'right', whiteSpace: 'nowrap' } }, revoke)
+        ]);
+        table.inject(row);
+    }
+
+    // Wrap in a horizontal scroller so the modal never overflows the viewport.
+    let scroller = new HTML('div', { style: { overflowX: 'auto' } });
+    scroller.inject(table);
+    list.inject(scroller);
+}
+
+// Create a new token and show the raw secret exactly once.
+async function create_token() {
+    let descEl = document.getElementById('token_desc');
+    let description = descEl ? descEl.value : "";
+    let scopes = [];
+    for (let s of ['read', 'write', 'admin']) {
+        let cb = document.getElementById('token_scope_' + s);
+        if (cb && cb.checked) {
+            scopes.push(s);
+        }
+    }
+    let res = await tokens_api({ action: 'create', description: description, scopes: scopes.join(' ') });
+    if (!res.json.okay) {
+        modal("Could not create token", res.json.message || "Unknown error.", "error");
+        return;
+    }
+
+    let body = document.getElementById('modal_text');
+    if (!body) {
+        return;
+    }
+    body.innerHTML = "";
+    body.inject(new HTML('p', {}, "Your new token is shown below. Copy it now — for security it will never be shown again:"));
+    let tokenBox = new HTML('textarea', {
+        readonly: 'readonly',
+        rows: "2",
+        style: { width: '100%' }
+    }, res.json.token);
+    body.inject(tokenBox);
+    body.inject(new HTML('p', {}, "Scopes: " + ((res.json.scopes || []).join(', ') || "read")));
+    if (res.json.expires) {
+        body.inject(new HTML('p', {}, "Expires: " + tokens_fmt_date(res.json.expires)));
+    } else {
+        body.inject(new HTML('p', {}, "This token does not expire."));
+    }
+    body.inject(new HTML('button', { onclick: 'manage_tokens();' }, "Back to token list"));
+
+    // Pre-select the secret for easy copying.
+    if (tokenBox.select) {
+        tokenBox.focus();
+        tokenBox.select();
+    }
+}
+
+// Revoke a token by id, after confirmation.
+async function revoke_token(id) {
+    if (!confirm("Revoke this token? Any scripts using it will immediately stop working.")) {
+        return;
+    }
+    let res = await tokens_api({ action: 'revoke', id: id });
+    if (!res.json.okay) {
+        modal("Could not revoke token", res.json.message || "Unknown error.", "error");
+        return;
+    }
+    await load_tokens();
+}


### PR DESCRIPTION
## Summary
Implements #312 — programmatic API access via an `Authorization: Bearer <token>` header, so scripts/automation can authenticate without a user's OAuth credentials and without the short session-cookie lifetime.

- Personal API tokens (create / list / revoke) via a new `/api/token` endpoint and a web-UI panel (user menu → **API Tokens**).
- Stored **SHA-256-hashed** (raw secret shown once); **opt-in** — `tokens.enabled`, disabled by default.
- **Per-action scopes** (`read` / `write` / `admin`): a token's access is the *intersection* of the owner's account permissions and its scopes, so a scope can only restrict, never escalate.
- **Live permission model** — a scope is a *wish, not a stored grant*. The server never snapshots permissions into a token: on every request it re-intersects the token's scopes with the owner's **current** account permissions. Lose a permission upstream → all your tokens lose it on their next request; there is nothing to cache-evict.
- **Cutting off a user's tokens**, on top of a user revoking individual tokens:
  - **Automatic** — `tokens.revoke_on_identity_change` (default **on**) purges a user's tokens on their next login if their OAuth identity/permissions changed (e.g. a credential reset upstream).
  - **Manual** — admins can purge *all* of a user's tokens at once via `mgmt.json`'s new `token_purge` action (by `cid` or `email`), audit-logged.
- CSRF-hardened management (JSON POST only), **audit-logged** create/revoke/purge, **expiry + background reaper**, and an optional in-memory auth cache (disabled by default).
- Invalid/expired/revoked tokens get an explicit **403** rather than a silent anonymous downgrade.

Docs included/updated: `API.md` (scope table + live-permission semantics + `token_purge`), `api_client_guide.md`, `configuration.md`, `openapi.yaml` (now also declares a `bearerAuth` security scheme), `AGENTS.md`, `architecture.md`, `admin_guide.md`, and a new `generating_api_clients.md` guide (auto-generate typed clients from the OpenAPI spec instead of hand-writing them).

## Commit
Single commit — source, docs, and tests only. Generated build artifacts (`webui/js/ponymail.js`, HTML `?revision=` bumps, `server_version.py`) are intentionally **not** included, per the earlier discussion in this PR: they're regenerated at build/release time via `build.sh` / `update_version.sh`.

## Testing
- **Manual / runtime e2e** against a live Foal + OpenSearch stack: login, create/list/revoke, the full scope-enforcement matrix (read-only denied compose/mgmt; an admin's read-only token still denied mgmt; scopes can't escalate), the CSRF guard, 403 on invalid/expired/revoked tokens, private-list access via bearer, the reaper, and the optional cache-TTL (delayed-revocation) behavior.
- **Visual**: verified the web-UI token panel (create with scope checkboxes, list, revoke).
- **End-to-end with the Pony Mail MCP**, which has a counterpart PR adding API-token support — the MCP authenticates to this endpoint with a bearer token end to end. Counterpart MCP PR: apache/comdev#23.
- `mypy`, `pylint` (10/10) and `pytest` unit tests all pass (unit tests cover the new identity-fingerprint / purge helpers).

## Flexibility
This is a sizable change and I'm happy to adapt it to what the maintainers want:
- **Split** into smaller PRs (e.g. core bearer auth → scopes → reaper/cache → UI) if that's easier to review and land.
- **Drop** any feature you'd rather not carry — the optional cache, the background reaper, per-action scopes, the auto/admin token purge, or the audit logging can each be removed independently without touching the core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

